### PR TITLE
Add unit trace rows and lightweight corpus eval runner

### DIFF
--- a/_bench/scripts/eval_corpus.py
+++ b/_bench/scripts/eval_corpus.py
@@ -1,0 +1,150 @@
+"""Run the corpus eval and emit stable regression artifacts.
+
+This is intentionally lightweight: one command converts a corpus directory,
+runs the existing FidelityOracle, writes a summary JSON, and writes the new
+unit-level trace JSONL used to train the cost model.
+
+Example:
+    python _bench/scripts/eval_corpus.py \
+        --corpus _bench/corpus \
+        --out _bench/eval_runs/latest
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from slidify.api import ConversionConfig, convert  # noqa: E402
+
+DEFAULT_THRESHOLDS = {
+    "mean_ssim_drop_max": 0.01,
+    "native_area_ratio_drop_max": 0.02,
+    "elapsed_growth_max": 0.20,
+}
+
+
+def _mean(vals: list[float]) -> float:
+    return statistics.fmean(vals) if vals else 0.0
+
+
+def _load_baseline(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _baseline_mean_ssim(raw: dict[str, Any]) -> float | None:
+    if not raw:
+        return None
+    if "mean_ssim" in raw:
+        return float(raw["mean_ssim"])
+    # Existing _bench/corpus/scores.json is a slide_name -> ssim map.
+    numeric = [float(v) for v in raw.values() if isinstance(v, int | float)]
+    return _mean(numeric) if numeric else None
+
+
+def _evaluate_thresholds(summary: dict[str, Any], baseline: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    baseline_ssim = _baseline_mean_ssim(baseline)
+    if baseline_ssim is not None:
+        drop = baseline_ssim - summary["metrics"]["mean_ssim"]
+        if drop > DEFAULT_THRESHOLDS["mean_ssim_drop_max"]:
+            warnings.append(
+                f"mean_ssim dropped {drop:.4f} from baseline {baseline_ssim:.4f}"
+            )
+    baseline_native = baseline.get("native_area_ratio") if baseline else None
+    if baseline_native is not None:
+        drop = float(baseline_native) - summary["metrics"]["native_area_ratio"]
+        if drop > DEFAULT_THRESHOLDS["native_area_ratio_drop_max"]:
+            warnings.append(
+                f"native_area_ratio dropped {drop:.4f} from baseline {float(baseline_native):.4f}"
+            )
+    baseline_elapsed = baseline.get("elapsed_seconds") if baseline else None
+    if baseline_elapsed:
+        growth = summary["metrics"]["elapsed_seconds"] / float(baseline_elapsed) - 1.0
+        if growth > DEFAULT_THRESHOLDS["elapsed_growth_max"]:
+            warnings.append(
+                f"elapsed_seconds grew {growth:.1%} from baseline {float(baseline_elapsed):.2f}s"
+            )
+    return warnings
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=Path, default=ROOT / "_bench" / "corpus")
+    parser.add_argument("--out", type=Path, default=ROOT / "_bench" / "eval_runs" / "latest")
+    parser.add_argument("--baseline", type=Path, default=ROOT / "_bench" / "corpus" / "scores.json")
+    parser.add_argument("--no-oracle", action="store_true", help="Skip LibreOffice/SSIM/OCR validation")
+    parser.add_argument("--tier3", action="store_true", help="Enable API-backed Tier-3 adjudication")
+    parser.add_argument("--include-text", action="store_true", help="Include text samples in trace rows")
+    args = parser.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    pptx_path = args.out / "deck.pptx"
+    trace_path = args.out / "trace.jsonl"
+    summary_path = args.out / "summary.json"
+
+    cfg = ConversionConfig(
+        run_oracle=not args.no_oracle,
+        run_tier3=args.tier3,
+        keep_plans_for_oracle=True,
+        trace_jsonl_path=trace_path,
+        trace_include_text=args.include_text,
+    )
+    result = await convert(args.corpus, pptx_path, cfg)
+
+    reports = result.fidelity_reports
+    ssim = [r.ssim for r in reports]
+    ocr = [r.ocr_recall for r in reports]
+    failing_units = sum(len(r.failing_units) for r in reports)
+    failing_regions = sum(len(r.failing_regions) for r in reports)
+
+    summary: dict[str, Any] = {
+        "corpus": str(args.corpus),
+        "pptx_path": str(pptx_path),
+        "trace_jsonl_path": str(trace_path),
+        "metrics": {
+            "n_slides": result.n_slides,
+            "native_area_ratio": result.native_area_ratio,
+            "mean_ssim": _mean(ssim),
+            "mean_ocr_recall": _mean(ocr),
+            "pass_rate": _mean([1.0 if r.passed else 0.0 for r in reports]),
+            "failing_regions": failing_regions,
+            "failing_units": failing_units,
+            "elapsed_seconds": result.elapsed_seconds,
+            "llm_calls": result.llm_calls,
+            "total_cost_usd": result.total_cost_usd,
+            "cache_hit_rate": result.cache_hit_rate,
+            "pattern_coverage": result.pattern_coverage,
+        },
+        "decisions_by_tier": result.decisions_by_tier,
+        "pattern_hits": result.pattern_hits,
+        "unmatched_signatures": [u.model_dump() for u in result.unmatched_signatures[:25]],
+        "slides": [r.model_dump(mode="json") for r in reports],
+    }
+
+    baseline = _load_baseline(args.baseline)
+    summary["warnings"] = _evaluate_thresholds(summary, baseline)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+
+    print(json.dumps(summary["metrics"], indent=2, sort_keys=True))
+    if summary["warnings"]:
+        print("\nWARNINGS:")
+        for warning in summary["warnings"]:
+            print(f"- {warning}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/slidify/api.py
+++ b/slidify/api.py
@@ -49,6 +49,7 @@ from slidify.patterns.signatures import signature, signature_hash
 from slidify.promotion import promote, to_emit_ops
 from slidify.renderer import Renderer
 from slidify.splitter import split_slides
+from slidify.trace import build_trace_rows, write_trace_jsonl
 from slidify.units import cluster, flatten
 
 log = structlog.get_logger(__name__)
@@ -84,6 +85,12 @@ class ConversionConfig:
             the auto-correction loop can re-emit failing slides natively.
             Set False on huge decks to drop plan state right after emit and
             rely on a single oracle pass without auto-correction.
+        trace_jsonl_path: optional path for unit-level JSONL trace rows used to
+            train/debug the cost model. When set, slide plans are retained until
+            the trace is written so rows can include final decisions and oracle
+            attribution.
+        trace_include_text: include a short text sample in trace rows. Defaults
+            to False to avoid leaking slide copy in shareable eval artifacts.
     """
 
     viewport: tuple[int, int] = (SLIDE_W_PX, SLIDE_H_PX)
@@ -113,6 +120,8 @@ class ConversionConfig:
     # On by default; disable for faster emit on decks where the
     # default-Office font is acceptable.
     embed_fonts: bool = True
+    trace_jsonl_path: str | Path | None = None
+    trace_include_text: bool = False
 
 
 @dataclass
@@ -338,6 +347,31 @@ async def _drain_in_batches(
         yield batch
 
 
+def _write_trace_if_requested(
+    cfg: ConversionConfig,
+    plans: list[_SlidePlan],
+    reports: list[FidelityReport],
+) -> None:
+    if cfg.trace_jsonl_path is None:
+        return
+    reports_by_slide = {r.slide_index: r for r in reports}
+    rows: list[dict] = []
+    for plan in plans:
+        if not plan.units_flat:
+            continue
+        rows.extend(
+            build_trace_rows(
+                slide_index=plan.index,
+                units=plan.units_flat,
+                decisions=plan.decisions,
+                report=reports_by_slide.get(plan.index),
+                include_text=cfg.trace_include_text,
+            )
+        )
+    write_trace_jsonl(cfg.trace_jsonl_path, rows)
+    log.info("api.trace_written", path=str(cfg.trace_jsonl_path), rows=len(rows))
+
+
 # -----------------------------------------------------------------------------
 # Public API
 # -----------------------------------------------------------------------------
@@ -410,7 +444,9 @@ async def convert(
                                 )
                         except Exception:
                             pass
-                    if cfg.run_oracle and cfg.keep_plans_for_oracle:
+                    if cfg.trace_jsonl_path is not None or (
+                        cfg.run_oracle and cfg.keep_plans_for_oracle
+                    ):
                         plans_for_oracle.append(plan)
                     else:
                         # Keep only ground-truth PNG if we still need it for oracle.
@@ -508,6 +544,7 @@ async def convert(
             reports = await _oracle_with_correction(
                 pptx_path, plans_for_oracle, summaries, cfg, renderer
             )
+        _write_trace_if_requested(cfg, plans_for_oracle, reports)
 
     n_slides = len(summaries)
     avg_native = (

--- a/slidify/trace.py
+++ b/slidify/trace.py
@@ -1,0 +1,143 @@
+"""Unit-level trace rows for training and debugging the cost model.
+
+The compiler already knows the useful facts: structural signatures, extracted
+cost-model features, decisions, and oracle attribution. This module joins those
+facts into JSONL rows so offline evals can fit a real model instead of tuning
+constants by hand.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from slidify.classifier.cost_model import MODEL_VERSION, extract_features, predict_costs
+from slidify.models import Decision, FidelityReport, VisualUnit
+from slidify.patterns.signatures import signature, signature_hash
+
+SCHEMA_VERSION = 1
+
+
+def _bbox_list(unit: VisualUnit) -> list[float]:
+    b = unit.bbox
+    return [b.x, b.y, b.w, b.h]
+
+
+def _decision_dict(decision: Decision | None) -> dict[str, Any]:
+    if decision is None:
+        return {
+            "kind": None,
+            "source_tier": None,
+            "confidence": 0.0,
+            "reason": "",
+            "metadata": {},
+        }
+    return {
+        "kind": decision.kind.value,
+        "source_tier": decision.source_tier,
+        "confidence": decision.confidence,
+        "reason": decision.reason,
+        "metadata": decision.metadata,
+    }
+
+
+def _sample_text(unit: VisualUnit) -> str:
+    parts: list[str] = []
+    for el in unit.all_elements():
+        if el.text and el.text.strip():
+            parts.append(el.text.strip())
+        if el.runs:
+            for run in el.runs:
+                if not run.is_break and run.text.strip():
+                    parts.append(run.text.strip())
+        if len(" ".join(parts)) > 240:
+            break
+    return " ".join(parts)[:240]
+
+
+def _attribution_by_unit(report: FidelityReport | None) -> dict[str, list[dict[str, Any]]]:
+    if report is None:
+        return {}
+    out: dict[str, list[dict[str, Any]]] = {}
+    for attr in report.failing_units:
+        out.setdefault(attr.unit_id, []).append(
+            {
+                "region": [
+                    attr.region.x,
+                    attr.region.y,
+                    attr.region.w,
+                    attr.region.h,
+                ],
+                "decision_kind": attr.decision_kind,
+                "source_tier": attr.source_tier,
+                "reason": attr.reason,
+                "suspected_failure": attr.suspected_failure,
+            }
+        )
+    return out
+
+
+def build_trace_rows(
+    *,
+    slide_index: int,
+    units: list[VisualUnit],
+    decisions: dict[str, Decision],
+    report: FidelityReport | None = None,
+    include_text: bool = False,
+) -> list[dict[str, Any]]:
+    """Build JSON-serializable trace rows for one slide.
+
+    Text is excluded by default so corpus/eval traces can be shared without
+    leaking slide copy. Set ``include_text=True`` only for local debugging.
+    """
+    by_unit = _attribution_by_unit(report)
+    rows: list[dict[str, Any]] = []
+    for unit in units:
+        decision = decisions.get(unit.id)
+        cost_features = extract_features(unit, decisions)
+        cost_prediction = predict_costs(unit, decisions)
+        failures = by_unit.get(unit.id, [])
+        row: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "slide_index": slide_index,
+            "unit_id": unit.id,
+            "signature_hash": signature_hash(unit),
+            "signature": signature(unit),
+            "bbox": _bbox_list(unit),
+            "features": asdict(cost_features),
+            "cost_model": {
+                "model_version": MODEL_VERSION,
+                "predicted_kind": cost_prediction.decision.value,
+                "confidence": cost_prediction.confidence,
+                "margin": cost_prediction.margin,
+                "expected_value": {
+                    "native": cost_prediction.native_ev,
+                    "hybrid": cost_prediction.hybrid_ev,
+                    "raster": cost_prediction.raster_ev,
+                },
+            },
+            "decision": _decision_dict(decision),
+            "oracle": {
+                "available": report is not None,
+                "slide_passed": report.passed if report is not None else None,
+                "ssim": report.ssim if report is not None else None,
+                "ocr_recall": report.ocr_recall if report is not None else None,
+                "attributed_failure": bool(failures),
+                "failures": failures,
+            },
+        }
+        if include_text:
+            row["sample_text"] = _sample_text(unit)
+        rows.append(row)
+    return rows
+
+
+def write_trace_jsonl(path: str | Path, rows: list[dict[str, Any]]) -> None:
+    """Write trace rows as newline-delimited JSON."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")

--- a/slidify/trace.py
+++ b/slidify/trace.py
@@ -135,9 +135,16 @@ def build_trace_rows(
 
 
 def write_trace_jsonl(path: str | Path, rows: list[dict[str, Any]]) -> None:
-    """Write trace rows as newline-delimited JSON."""
+    """Write trace rows as newline-delimited JSON.
+
+    Classifier metadata is supposed to be primitive JSON, but using default=str
+    makes the trace writer resilient to future metadata that carries enums,
+    paths, or tiny helper dataclasses.
+    """
     out = Path(path)
     out.parent.mkdir(parents=True, exist_ok=True)
     with out.open("w", encoding="utf-8") as f:
         for row in rows:
-            f.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+            f.write(
+                json.dumps(row, ensure_ascii=False, sort_keys=True, default=str) + "\n"
+            )

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+
+from slidify.models import (
+    BoundingBox,
+    Decision,
+    DecisionKind,
+    DomElement,
+    FailingUnitAttribution,
+    FidelityReport,
+    VisualUnit,
+)
+from slidify.trace import build_trace_rows, write_trace_jsonl
+
+
+def _el(id_: int, text: str = "Hello") -> DomElement:
+    return DomElement(
+        id=id_,
+        parent_id=None,
+        depth=0,
+        tag="DIV",
+        bbox=BoundingBox(x=10, y=20, w=200, h=50),
+        text=text,
+        font_family="Inter",
+        font_size="24px",
+        font_weight="700",
+        color="rgb(255, 255, 255)",
+    )
+
+
+def _unit() -> VisualUnit:
+    return VisualUnit(
+        id="u_1",
+        bbox=BoundingBox(x=10, y=20, w=200, h=50),
+        elements=[_el(1)],
+    )
+
+
+def test_build_trace_rows_omits_text_by_default() -> None:
+    unit = _unit()
+    decision = Decision(
+        kind=DecisionKind.NativeText,
+        confidence=0.93,
+        reason="test_native",
+        source_tier="tier2:model",
+    )
+    rows = build_trace_rows(
+        slide_index=0,
+        units=[unit],
+        decisions={unit.id: decision},
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["schema_version"] == 1
+    assert row["slide_index"] == 0
+    assert row["unit_id"] == "u_1"
+    assert "sample_text" not in row
+    assert row["decision"]["kind"] == "native_text"
+    assert row["decision"]["source_tier"] == "tier2:model"
+    assert row["features"]["has_own_text"] is True
+    assert row["cost_model"]["expected_value"]["native"] is not None
+    assert row["oracle"]["available"] is False
+
+
+def test_build_trace_rows_can_include_text_when_explicitly_enabled() -> None:
+    unit = _unit()
+    rows = build_trace_rows(
+        slide_index=0,
+        units=[unit],
+        decisions={},
+        include_text=True,
+    )
+
+    assert rows[0]["sample_text"] == "Hello"
+
+
+def test_build_trace_rows_attaches_oracle_attribution() -> None:
+    unit = _unit()
+    report = FidelityReport(
+        slide_index=0,
+        ssim=0.72,
+        ocr_recall=0.81,
+        passed=False,
+        failing_units=[
+            FailingUnitAttribution(
+                region=BoundingBox(x=12, y=22, w=40, h=10),
+                unit_id="u_1",
+                decision_kind="NativeText",
+                source_tier="tier2:model",
+                reason="test_native",
+                suspected_failure="font_metrics",
+            )
+        ],
+    )
+
+    rows = build_trace_rows(
+        slide_index=0,
+        units=[unit],
+        decisions={},
+        report=report,
+    )
+
+    oracle = rows[0]["oracle"]
+    assert oracle["available"] is True
+    assert oracle["slide_passed"] is False
+    assert oracle["ssim"] == 0.72
+    assert oracle["attributed_failure"] is True
+    assert oracle["failures"][0]["suspected_failure"] == "font_metrics"
+
+
+def test_write_trace_jsonl_round_trips(tmp_path) -> None:
+    out = tmp_path / "trace.jsonl"
+    write_trace_jsonl(out, [{"b": 2, "a": 1}, {"c": 3}])
+
+    rows = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+    assert rows == [{"a": 1, "b": 2}, {"c": 3}]


### PR DESCRIPTION
## Summary
- Add `slidify.trace`, which joins structural signatures, cost-model features, decisions, and oracle attribution into stable JSONL rows.
- Add `ConversionConfig.trace_jsonl_path` and `trace_include_text`; trace rows are written after oracle correction so rows reflect final decisions and final attribution.
- Add unit tests for the trace schema, privacy default, attribution join, and JSONL round-trip.
- Add `_bench/scripts/eval_corpus.py`, a lightweight corpus runner that emits `deck.pptx`, `trace.jsonl`, and `summary.json` with regression warnings.

## Why
This turns the cost model from a calibrated prior into something trainable. The compiler now emits one row per unit with:
- structural signature/hash
- extracted cost-model features
- model EV/margin
- chosen decision + tier + metadata
- optional SSIM/OCR and failing-unit attribution

## Usage
```bash
python _bench/scripts/eval_corpus.py \
  --corpus _bench/corpus \
  --out _bench/eval_runs/latest
```

For local debugging only:
```bash
python _bench/scripts/eval_corpus.py --include-text
```

## Issue links
- Addresses #8: oracle-labelled unit rows for cost-model training.
- Partially addresses #5: lightweight eval runner and baseline warnings.

## Testing
Not run in this environment. Suggested checks:
```bash
uv run pytest tests/unit/test_trace.py
uv run pytest
python _bench/scripts/eval_corpus.py --no-oracle --out /tmp/pixelpitch-eval-smoke
```