### PR TITLE
SVG path: translate arc commands (A/a) to cubic Beziers

### DIFF
--- a/_bench/corpus/report.json
+++ b/_bench/corpus/report.json
@@ -3,7 +3,7 @@
   "n_ok": 48,
   "n_failed": 0,
   "mean_native_area_ratio": 1.0,
-  "total_unmatched": 138,
+  "total_unmatched": 136,
   "rows": [
     {
       "slide": "slide-01-state-of-the-union.html",
@@ -15,28 +15,28 @@
         "tier0": 12,
         "tier1": 3,
         "cache:tier1": 4,
-        "cache:tier0": 4
+        "cache:tier0": 2
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.5930665699997917,
+      "elapsed_s": 2.2054372529999,
       "pptx": "_bench/corpus/out/slide-01-state-of-the-union.pptx",
-      "preview_png": "_bench/corpus/preview/slide-01-state-of-the-union.png"
+      "preview_png": null
     },
     {
       "slide": "slide-02-the-deficit-two-ways.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.8461538461538461,
+      "pattern_coverage": 0.9230769230769231,
       "decisions_by_tier": {
-        "tier0": 11,
-        "cache:tier0": 8,
-        "tier1": 2
+        "tier0": 12,
+        "tier1": 1,
+        "cache:tier0": 3
       },
-      "unmatched_signatures": 2,
-      "elapsed_s": 1.7372071039999355,
+      "unmatched_signatures": 1,
+      "elapsed_s": 1.8094982630000231,
       "pptx": "_bench/corpus/out/slide-02-the-deficit-two-ways.pptx",
-      "preview_png": "_bench/corpus/preview/slide-02-the-deficit-two-ways.png"
+      "preview_png": null
     },
     {
       "slide": "slide-03-housing-six-cities.html",
@@ -51,9 +51,9 @@
         "cache:tier1": 3
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.5466581749997204,
+      "elapsed_s": 1.7835736479999014,
       "pptx": "_bench/corpus/out/slide-03-housing-six-cities.pptx",
-      "preview_png": "_bench/corpus/preview/slide-03-housing-six-cities.png"
+      "preview_png": null
     },
     {
       "slide": "slide-04-the-quiet-collapse.html",
@@ -67,9 +67,9 @@
         "tier1": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 1.489304068999445,
+      "elapsed_s": 1.7540885240000534,
       "pptx": "_bench/corpus/out/slide-04-the-quiet-collapse.pptx",
-      "preview_png": "_bench/corpus/preview/slide-04-the-quiet-collapse.png"
+      "preview_png": null
     },
     {
       "slide": "slide-05-broadband-by-state.html",
@@ -80,14 +80,14 @@
       "decisions_by_tier": {
         "tier0": 14,
         "tier1": 4,
-        "cache:tier0": 85,
+        "cache:tier0": 51,
         "cache:tier1": 8,
         "promotion": 1
       },
       "unmatched_signatures": 4,
-      "elapsed_s": 2.1655455089994575,
+      "elapsed_s": 1.9162042799998744,
       "pptx": "_bench/corpus/out/slide-05-broadband-by-state.pptx",
-      "preview_png": "_bench/corpus/preview/slide-05-broadband-by-state.png"
+      "preview_png": null
     },
     {
       "slide": "slide-06-emissions-comparison.html",
@@ -102,9 +102,9 @@
         "cache:tier1": 7
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 1.5595566040001358,
+      "elapsed_s": 1.8941005929998482,
       "pptx": "_bench/corpus/out/slide-06-emissions-comparison.pptx",
-      "preview_png": "_bench/corpus/preview/slide-06-emissions-comparison.png"
+      "preview_png": null
     },
     {
       "slide": "slide-07-cover-the-numbers.html",
@@ -119,9 +119,9 @@
         "cache:tier1": 3
       },
       "unmatched_signatures": 7,
-      "elapsed_s": 1.50396161900062,
+      "elapsed_s": 1.8105116970000381,
       "pptx": "_bench/corpus/out/slide-07-cover-the-numbers.pptx",
-      "preview_png": "_bench/corpus/preview/slide-07-cover-the-numbers.png"
+      "preview_png": null
     },
     {
       "slide": "slide-11-hero-number.html",
@@ -134,9 +134,9 @@
         "cache:tier0": 1
       },
       "unmatched_signatures": 0,
-      "elapsed_s": 1.3901427990003867,
+      "elapsed_s": 1.6257672549998006,
       "pptx": "_bench/corpus/out/slide-11-hero-number.pptx",
-      "preview_png": "_bench/corpus/preview/slide-11-hero-number.png"
+      "preview_png": null
     },
     {
       "slide": "slide-12-title-reveal.html",
@@ -149,9 +149,9 @@
         "cache:tier0": 1
       },
       "unmatched_signatures": 0,
-      "elapsed_s": 1.3714847870005542,
+      "elapsed_s": 1.6059527140000682,
       "pptx": "_bench/corpus/out/slide-12-title-reveal.pptx",
-      "preview_png": "_bench/corpus/preview/slide-12-title-reveal.png"
+      "preview_png": null
     },
     {
       "slide": "slide-13-spec-sheet.html",
@@ -166,9 +166,9 @@
         "cache:tier1": 3
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.4227821929998754,
+      "elapsed_s": 1.739996409000014,
       "pptx": "_bench/corpus/out/slide-13-spec-sheet.pptx",
-      "preview_png": "_bench/corpus/preview/slide-13-spec-sheet.png"
+      "preview_png": null
     },
     {
       "slide": "slide-14-was-now.html",
@@ -182,26 +182,26 @@
         "cache:tier0": 3
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 1.6168847039998582,
+      "elapsed_s": 1.6724238220001553,
       "pptx": "_bench/corpus/out/slide-14-was-now.pptx",
-      "preview_png": "_bench/corpus/preview/slide-14-was-now.png"
+      "preview_png": null
     },
     {
       "slide": "slide-15-feature-mosaic.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.6,
+      "pattern_coverage": 0.5555555555555556,
       "decisions_by_tier": {
-        "tier0": 6,
+        "tier0": 5,
         "tier1": 4,
-        "cache:tier0": 2,
+        "cache:tier0": 3,
         "cache:tier1": 4
       },
       "unmatched_signatures": 4,
-      "elapsed_s": 1.4711774220004372,
+      "elapsed_s": 1.6043629010000586,
       "pptx": "_bench/corpus/out/slide-15-feature-mosaic.pptx",
-      "preview_png": "_bench/corpus/preview/slide-15-feature-mosaic.png"
+      "preview_png": null
     },
     {
       "slide": "slide-16-pull-quote.html",
@@ -215,9 +215,9 @@
         "tier1": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 1.6930563300002177,
+      "elapsed_s": 1.970989136000071,
       "pptx": "_bench/corpus/out/slide-16-pull-quote.pptx",
-      "preview_png": "_bench/corpus/preview/slide-16-pull-quote.png"
+      "preview_png": null
     },
     {
       "slide": "slide-17-thank-you.html",
@@ -231,9 +231,9 @@
         "cache:tier0": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 1.4346002120000776,
+      "elapsed_s": 1.5410264570000436,
       "pptx": "_bench/corpus/out/slide-17-thank-you.pptx",
-      "preview_png": "_bench/corpus/preview/slide-17-thank-you.png"
+      "preview_png": null
     },
     {
       "slide": "slide-21-spec-sheet.html",
@@ -248,9 +248,9 @@
         "cache:tier1": 5
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.3752197980002165,
+      "elapsed_s": 1.5550353490000361,
       "pptx": "_bench/corpus/out/slide-21-spec-sheet.pptx",
-      "preview_png": "_bench/corpus/preview/slide-21-spec-sheet.png"
+      "preview_png": null
     },
     {
       "slide": "slide-22-schematic.html",
@@ -265,9 +265,9 @@
         "cache:tier1": 15
       },
       "unmatched_signatures": 4,
-      "elapsed_s": 1.5460700370003906,
+      "elapsed_s": 1.5978185409999242,
       "pptx": "_bench/corpus/out/slide-22-schematic.pptx",
-      "preview_png": "_bench/corpus/preview/slide-22-schematic.png"
+      "preview_png": null
     },
     {
       "slide": "slide-23-density-grid.html",
@@ -282,9 +282,9 @@
         "tier2": 1
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.680963740000152,
+      "elapsed_s": 1.681837559000087,
       "pptx": "_bench/corpus/out/slide-23-density-grid.pptx",
-      "preview_png": "_bench/corpus/preview/slide-23-density-grid.png"
+      "preview_png": null
     },
     {
       "slide": "slide-24-code-hero.html",
@@ -299,9 +299,9 @@
         "cache:tier1": 3
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 1.6574832969999989,
+      "elapsed_s": 1.5124534209999183,
       "pptx": "_bench/corpus/out/slide-24-code-hero.pptx",
-      "preview_png": "_bench/corpus/preview/slide-24-code-hero.png"
+      "preview_png": null
     },
     {
       "slide": "slide-25-status-board.html",
@@ -316,9 +316,9 @@
         "tier2": 1
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.6953638479999427,
+      "elapsed_s": 1.5948826769999869,
       "pptx": "_bench/corpus/out/slide-25-status-board.pptx",
-      "preview_png": "_bench/corpus/preview/slide-25-status-board.png"
+      "preview_png": null
     },
     {
       "slide": "slide-26-manifesto.html",
@@ -332,9 +332,9 @@
         "tier1": 2
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 1.5164005469996482,
+      "elapsed_s": 1.5193390379999983,
       "pptx": "_bench/corpus/out/slide-26-manifesto.pptx",
-      "preview_png": "_bench/corpus/preview/slide-26-manifesto.png"
+      "preview_png": null
     },
     {
       "slide": "slide-27-dotmatrix-ladder.html",
@@ -349,9 +349,9 @@
         "tier2": 3
       },
       "unmatched_signatures": 7,
-      "elapsed_s": 1.6540367440002228,
+      "elapsed_s": 1.671783287000153,
       "pptx": "_bench/corpus/out/slide-27-dotmatrix-ladder.pptx",
-      "preview_png": "_bench/corpus/preview/slide-27-dotmatrix-ladder.png"
+      "preview_png": null
     },
     {
       "slide": "slide-31-hero-gradient.html",
@@ -367,29 +367,29 @@
         "promotion": 1
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.8800068670007022,
+      "elapsed_s": 2.053551212000002,
       "pptx": "_bench/corpus/out/slide-31-hero-gradient.pptx",
-      "preview_png": "_bench/corpus/preview/slide-31-hero-gradient.png"
+      "preview_png": null
     },
     {
       "slide": "slide-32-stats-trio.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.75,
+      "pattern_coverage": 0.7619047619047619,
       "decisions_by_tier": {
-        "tier0": 14,
+        "tier0": 15,
         "tier1": 2,
-        "cache:tier0": 10,
         "tier2": 3,
         "cache:tier1": 4,
+        "cache:tier0": 9,
         "cache:tier2": 1,
         "promotion": 1
       },
       "unmatched_signatures": 5,
-      "elapsed_s": 1.849492962000113,
+      "elapsed_s": 2.087565614999903,
       "pptx": "_bench/corpus/out/slide-32-stats-trio.pptx",
-      "preview_png": "_bench/corpus/preview/slide-32-stats-trio.png"
+      "preview_png": null
     },
     {
       "slide": "slide-33-pricing-tiers.html",
@@ -404,28 +404,28 @@
         "promotion": 2
       },
       "unmatched_signatures": 4,
-      "elapsed_s": 1.9895527580001726,
+      "elapsed_s": 2.220957460999898,
       "pptx": "_bench/corpus/out/slide-33-pricing-tiers.pptx",
-      "preview_png": "_bench/corpus/preview/slide-33-pricing-tiers.png"
+      "preview_png": null
     },
     {
       "slide": "slide-34-feature-bento.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.7,
+      "pattern_coverage": 0.7586206896551724,
       "decisions_by_tier": {
-        "tier0": 20,
+        "tier0": 21,
         "cache:tier0": 30,
-        "tier1": 5,
-        "cache:tier1": 3,
+        "tier1": 3,
+        "cache:tier1": 4,
         "tier2": 2,
         "promotion": 3
       },
-      "unmatched_signatures": 9,
-      "elapsed_s": 2.0503592659997594,
+      "unmatched_signatures": 7,
+      "elapsed_s": 2.3159940460000144,
       "pptx": "_bench/corpus/out/slide-34-feature-bento.pptx",
-      "preview_png": "_bench/corpus/preview/slide-34-feature-bento.png"
+      "preview_png": null
     },
     {
       "slide": "slide-35-quote-wall.html",
@@ -443,9 +443,9 @@
         "promotion": 1
       },
       "unmatched_signatures": 4,
-      "elapsed_s": 2.0243864080002822,
+      "elapsed_s": 2.155112233999944,
       "pptx": "_bench/corpus/out/slide-35-quote-wall.pptx",
-      "preview_png": "_bench/corpus/preview/slide-35-quote-wall.png"
+      "preview_png": null
     },
     {
       "slide": "slide-36-cta-closing.html",
@@ -460,9 +460,9 @@
         "promotion": 1
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 2.0115247600006114,
+      "elapsed_s": 2.139024698999947,
       "pptx": "_bench/corpus/out/slide-36-cta-closing.pptx",
-      "preview_png": "_bench/corpus/preview/slide-36-cta-closing.png"
+      "preview_png": null
     },
     {
       "slide": "slide-37-logo-mosaic.html",
@@ -477,24 +477,25 @@
         "promotion": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 2.0100563150008384,
+      "elapsed_s": 2.095179967000149,
       "pptx": "_bench/corpus/out/slide-37-logo-mosaic.pptx",
-      "preview_png": "_bench/corpus/preview/slide-37-logo-mosaic.png"
+      "preview_png": null
     },
     {
       "slide": "slide-41-hero-blob-frame.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.6666666666666666,
+      "pattern_coverage": 0.75,
       "decisions_by_tier": {
         "tier0": 6,
-        "tier1": 3
+        "tier1": 2,
+        "cache:tier1": 1
       },
-      "unmatched_signatures": 3,
-      "elapsed_s": 2.151705884999501,
+      "unmatched_signatures": 2,
+      "elapsed_s": 2.2546728180000173,
       "pptx": "_bench/corpus/out/slide-41-hero-blob-frame.pptx",
-      "preview_png": "_bench/corpus/preview/slide-41-hero-blob-frame.png"
+      "preview_png": null
     },
     {
       "slide": "slide-42-story-pullquote.html",
@@ -508,26 +509,26 @@
         "cache:tier0": 1
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 1.574815399999352,
+      "elapsed_s": 1.757015168999942,
       "pptx": "_bench/corpus/out/slide-42-story-pullquote.pptx",
-      "preview_png": "_bench/corpus/preview/slide-42-story-pullquote.png"
+      "preview_png": null
     },
     {
       "slide": "slide-43-ritual-steps.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.8,
+      "pattern_coverage": 0.7777777777777778,
       "decisions_by_tier": {
-        "tier0": 8,
+        "tier0": 7,
         "tier1": 2,
-        "cache:tier0": 8,
+        "cache:tier0": 9,
         "cache:tier1": 3
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 1.6657284279999658,
+      "elapsed_s": 1.762037237999948,
       "pptx": "_bench/corpus/out/slide-43-ritual-steps.pptx",
-      "preview_png": "_bench/corpus/preview/slide-43-ritual-steps.png"
+      "preview_png": null
     },
     {
       "slide": "slide-44-feature-breathing.html",
@@ -541,9 +542,9 @@
         "tier1": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 1.626542537000205,
+      "elapsed_s": 1.6712757829998282,
       "pptx": "_bench/corpus/out/slide-44-feature-breathing.pptx",
-      "preview_png": "_bench/corpus/preview/slide-44-feature-breathing.png"
+      "preview_png": null
     },
     {
       "slide": "slide-45-quote-testimonial.html",
@@ -557,9 +558,9 @@
         "cache:tier0": 1
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 1.6998055049998584,
+      "elapsed_s": 1.6852521000000706,
       "pptx": "_bench/corpus/out/slide-45-quote-testimonial.pptx",
-      "preview_png": "_bench/corpus/preview/slide-45-quote-testimonial.png"
+      "preview_png": null
     },
     {
       "slide": "slide-46-call-to-rest.html",
@@ -573,78 +574,78 @@
         "tier1": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 1.5908633919998465,
+      "elapsed_s": 1.6477492269998493,
       "pptx": "_bench/corpus/out/slide-46-call-to-rest.pptx",
-      "preview_png": "_bench/corpus/preview/slide-46-call-to-rest.png"
+      "preview_png": null
     },
     {
       "slide": "slide-47-manifesto-values.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.9375,
+      "pattern_coverage": 0.9285714285714286,
       "decisions_by_tier": {
-        "tier0": 15,
-        "cache:tier0": 5,
+        "tier0": 13,
+        "cache:tier0": 7,
         "tier1": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 1.6570077510004921,
+      "elapsed_s": 1.6661978270001327,
       "pptx": "_bench/corpus/out/slide-47-manifesto-values.pptx",
-      "preview_png": "_bench/corpus/preview/slide-47-manifesto-values.png"
+      "preview_png": null
     },
     {
       "slide": "slide-51-strategic-matrix.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.7777777777777778,
+      "pattern_coverage": 0.7692307692307693,
       "decisions_by_tier": {
-        "tier0": 21,
+        "tier0": 20,
         "tier1": 3,
         "cache:tier1": 3,
-        "cache:tier0": 24,
+        "cache:tier0": 25,
         "tier2": 3,
         "cache:tier2": 9
       },
       "unmatched_signatures": 6,
-      "elapsed_s": 1.797880979999718,
+      "elapsed_s": 1.8340736269999525,
       "pptx": "_bench/corpus/out/slide-51-strategic-matrix.pptx",
-      "preview_png": "_bench/corpus/preview/slide-51-strategic-matrix.png"
+      "preview_png": null
     },
     {
       "slide": "slide-52-stacked-bar.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.9411764705882353,
+      "pattern_coverage": 0.9117647058823529,
       "decisions_by_tier": {
-        "tier0": 32,
-        "tier1": 2,
-        "cache:tier0": 35,
-        "cache:tier1": 2
+        "tier0": 31,
+        "tier1": 3,
+        "cache:tier1": 2,
+        "cache:tier0": 32
       },
-      "unmatched_signatures": 2,
-      "elapsed_s": 1.8388762399999905,
+      "unmatched_signatures": 3,
+      "elapsed_s": 1.9863885440001923,
       "pptx": "_bench/corpus/out/slide-52-stacked-bar.pptx",
-      "preview_png": "_bench/corpus/preview/slide-52-stacked-bar.png"
+      "preview_png": null
     },
     {
       "slide": "slide-53-comparison-table.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.6923076923076923,
+      "pattern_coverage": 0.6538461538461539,
       "decisions_by_tier": {
-        "tier0": 18,
+        "tier0": 17,
         "tier1": 2,
-        "cache:tier0": 55,
-        "tier2": 6
+        "cache:tier0": 51,
+        "tier2": 7
       },
-      "unmatched_signatures": 8,
-      "elapsed_s": 1.6357527689997369,
+      "unmatched_signatures": 9,
+      "elapsed_s": 1.7281308139999965,
       "pptx": "_bench/corpus/out/slide-53-comparison-table.pptx",
-      "preview_png": "_bench/corpus/preview/slide-53-comparison-table.png"
+      "preview_png": null
     },
     {
       "slide": "slide-54-numbered-insights.html",
@@ -659,9 +660,9 @@
         "cache:tier1": 4
       },
       "unmatched_signatures": 2,
-      "elapsed_s": 1.7779720110002017,
+      "elapsed_s": 1.891846674000135,
       "pptx": "_bench/corpus/out/slide-54-numbered-insights.pptx",
-      "preview_png": "_bench/corpus/preview/slide-54-numbered-insights.png"
+      "preview_png": null
     },
     {
       "slide": "slide-55-waterfall.html",
@@ -677,9 +678,9 @@
         "cache:tier2": 4
       },
       "unmatched_signatures": 4,
-      "elapsed_s": 1.862921073000507,
+      "elapsed_s": 1.9791321959999095,
       "pptx": "_bench/corpus/out/slide-55-waterfall.pptx",
-      "preview_png": "_bench/corpus/preview/slide-55-waterfall.png"
+      "preview_png": null
     },
     {
       "slide": "slide-56-cover.html",
@@ -694,9 +695,9 @@
         "cache:tier1": 18
       },
       "unmatched_signatures": 5,
-      "elapsed_s": 1.640585330000249,
+      "elapsed_s": 1.7835377630001403,
       "pptx": "_bench/corpus/out/slide-56-cover.pptx",
-      "preview_png": "_bench/corpus/preview/slide-56-cover.png"
+      "preview_png": null
     },
     {
       "slide": "slide-57-ranking.html",
@@ -713,9 +714,9 @@
         "cache:tier2": 5
       },
       "unmatched_signatures": 7,
-      "elapsed_s": 1.9195606299999781,
+      "elapsed_s": 2.006853091000039,
       "pptx": "_bench/corpus/out/slide-57-ranking.pptx",
-      "preview_png": "_bench/corpus/preview/slide-57-ranking.png"
+      "preview_png": null
     },
     {
       "slide": "slide-61-magazine-cover-mask.html",
@@ -730,9 +731,9 @@
         "promotion": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 3.326809009000499,
+      "elapsed_s": 3.398126601000058,
       "pptx": "_bench/corpus/out/slide-61-magazine-cover-mask.pptx",
-      "preview_png": "_bench/corpus/preview/slide-61-magazine-cover-mask.png"
+      "preview_png": null
     },
     {
       "slide": "slide-62-magazine-spread.html",
@@ -746,27 +747,27 @@
         "cache:tier1": 1
       },
       "unmatched_signatures": 1,
-      "elapsed_s": 2.0827251239998077,
+      "elapsed_s": 2.578225470999996,
       "pptx": "_bench/corpus/out/slide-62-magazine-spread.pptx",
-      "preview_png": "_bench/corpus/preview/slide-62-magazine-spread.png"
+      "preview_png": null
     },
     {
       "slide": "slide-63-photo-essay-caption.html",
       "ok": true,
       "n_slides": 1,
       "native_area_ratio": 1.0,
-      "pattern_coverage": 0.7272727272727273,
+      "pattern_coverage": 0.75,
       "decisions_by_tier": {
-        "tier0": 8,
+        "tier0": 9,
         "tier1": 1,
         "cache:tier1": 1,
         "promotion": 2,
-        "cache:tier0": 2
+        "cache:tier0": 1
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 3.4702892939994854,
+      "elapsed_s": 3.6034576980000566,
       "pptx": "_bench/corpus/out/slide-63-photo-essay-caption.pptx",
-      "preview_png": "_bench/corpus/preview/slide-63-photo-essay-caption.png"
+      "preview_png": null
     },
     {
       "slide": "slide-64-pull-quote-faded.html",
@@ -775,14 +776,14 @@
       "native_area_ratio": 1.0,
       "pattern_coverage": 1.0,
       "decisions_by_tier": {
-        "tier0": 10,
-        "cache:tier0": 4,
+        "tier0": 11,
+        "cache:tier0": 3,
         "promotion": 1
       },
       "unmatched_signatures": 0,
-      "elapsed_s": 2.5854942209998626,
+      "elapsed_s": 2.920042724000041,
       "pptx": "_bench/corpus/out/slide-64-pull-quote-faded.pptx",
-      "preview_png": "_bench/corpus/preview/slide-64-pull-quote-faded.png"
+      "preview_png": null
     },
     {
       "slide": "slide-65-mosaic-gallery.html",
@@ -797,9 +798,9 @@
         "cache:tier1": 3
       },
       "unmatched_signatures": 3,
-      "elapsed_s": 1.9821030740004062,
+      "elapsed_s": 2.2949550860000727,
       "pptx": "_bench/corpus/out/slide-65-mosaic-gallery.pptx",
-      "preview_png": "_bench/corpus/preview/slide-65-mosaic-gallery.png"
+      "preview_png": null
     },
     {
       "slide": "slide-66-duotone-hero.html",
@@ -808,14 +809,14 @@
       "native_area_ratio": 1.0,
       "pattern_coverage": 1.0,
       "decisions_by_tier": {
-        "tier0": 13,
-        "cache:tier0": 5,
+        "tier0": 14,
+        "cache:tier0": 4,
         "promotion": 1
       },
       "unmatched_signatures": 0,
-      "elapsed_s": 3.903176243999951,
+      "elapsed_s": 4.330868210000062,
       "pptx": "_bench/corpus/out/slide-66-duotone-hero.pptx",
-      "preview_png": "_bench/corpus/preview/slide-66-duotone-hero.png"
+      "preview_png": null
     }
   ]
 }

--- a/slidify/classifier/tier1.py
+++ b/slidify/classifier/tier1.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from slidify.dom_walker import SVG_NATIVE_PATH_BUDGET
 from slidify.geom import parse_px
 from slidify.gradients import parse_gradient
 from slidify.models import Decision, DecisionKind, UnitKind, VisualUnit
@@ -28,9 +29,11 @@ def _has_complex_svg(unit: VisualUnit) -> bool:
     # child unit's SVG should fire its own classifier; bubbling the rule
     # up to the parent caused the slide-level unit to absorb every
     # sibling box's emit (slide 04 went 48 -> 3 shapes). Threshold
-    # mirrors the dom_walker capture cap (30) so any SVG that the
-    # walker could capture stays on the native path.
-    return any(e.is_svg and e.svg_path_count > 30 for e in unit.elements)
+    # mirrors the dom_walker capture cap (SVG_NATIVE_PATH_BUDGET) so any
+    # SVG that the walker could capture stays on the native path.
+    return any(
+        e.is_svg and e.svg_path_count > SVG_NATIVE_PATH_BUDGET for e in unit.elements
+    )
 
 
 def _has_simple_svg(unit: VisualUnit) -> bool:

--- a/slidify/dom_walker.py
+++ b/slidify/dom_walker.py
@@ -274,8 +274,33 @@ WALKER_JS = r"""
                     }
                     // Embed _svgRect on every shape dict — JS array
                     // properties don't survive JSON serialization, but
-                    // dict items do.
-                    const rect = { x: svgRect.x, y: svgRect.y, w: svgRect.width, h: svgRect.height };
+                    // dict items do. Capture viewBox + preserveAspectRatio
+                    // so the Python side can map SVG userspace units (which
+                    // may be very different from viewport pixels) into the
+                    // slide. Without this, an SVG with viewBox="0 0 100 100"
+                    // rendered into a 1280×720 box has every coordinate off
+                    // by a factor of ~12.
+                    let viewBox = null;
+                    try {
+                        const vb = el.viewBox && el.viewBox.baseVal;
+                        if (vb && (vb.width > 0 || vb.height > 0)) {
+                            viewBox = [vb.x, vb.y, vb.width, vb.height];
+                        } else if (el.getAttribute('viewBox')) {
+                            const parts = el.getAttribute('viewBox').trim().split(/[\s,]+/).map(parseFloat);
+                            if (parts.length === 4 && parts.every(n => Number.isFinite(n))) {
+                                viewBox = parts;
+                            }
+                        }
+                    } catch (_) {}
+                    const preserveAspectRatio = el.getAttribute('preserveAspectRatio') || null;
+                    const rect = {
+                        x: svgRect.x,
+                        y: svgRect.y,
+                        w: svgRect.width,
+                        h: svgRect.height,
+                        viewBox: viewBox,
+                        preserveAspectRatio: preserveAspectRatio,
+                    };
                     for (const sh of svgShapes) sh._svgRect = rect;
                 }
             } catch (_) {}

--- a/slidify/dom_walker.py
+++ b/slidify/dom_walker.py
@@ -8,10 +8,21 @@ from playwright.async_api import Page
 
 from slidify.models import BoundingBox, DomElement, TextRun
 
+# Maximum SVG primitive count that the walker captures geometry for and that
+# the tier-1 classifier accepts on the native path. Beyond this, the SVG is
+# treated as a complex illustration and rasterized cleanly. The two sites
+# (this constant and `classifier.tier1._has_complex_svg`) MUST stay aligned —
+# a mismatch creates a "dead band" where the walker drops geometry but the
+# classifier still routes the unit to the native emitter, which then emits
+# an empty shell. Real-world charts (50+ data points + axis ticks + gridlines)
+# and architecture diagrams (40-80 connectors) routinely exceed the previous
+# cap of 30; the bumped budget keeps them on the native path.
+SVG_NATIVE_PATH_BUDGET = 200
+
 # Walks the DOM in-page and produces an array of element records.
 # Skips invisible elements and <head>. Captures bbox, computed style,
 # pseudo-element presence, and slidify hints.
-WALKER_JS = r"""
+_WALKER_JS_TEMPLATE = r"""
 () => {
     const out = [];
     let nextId = 0;
@@ -207,14 +218,15 @@ WALKER_JS = r"""
                     el.querySelectorAll('text')
                 ).filter(t => !inDefs(t));
                 svgPathCount = allShapes.length;
-                // Capture geometry for SVGs up to ~30 primitives. Architecture
-                // diagrams, dashboard charts and process flows routinely
-                // ship 10-25 primitives, and rasterizing them loses every
-                // connector + axis line. The classifier's simple/complex
-                // SVG rules now scope to a unit's direct elements only,
-                // so a large overlay SVG no longer absorbs sibling content
-                // even when its bbox spans most of the slide.
-                if (svgPathCount > 0 && svgPathCount <= 30) {
+                // Capture geometry for SVGs up to __SVG_NATIVE_PATH_BUDGET__
+                // primitives (kept in sync with classifier.tier1). Real-world
+                // charts (line/bar with 50+ data points + ticks + gridlines)
+                // and architecture diagrams (40-80 connectors) routinely
+                // exceed the older cap of 30. The classifier's simple/complex
+                // SVG rules scope to a unit's direct elements only, so a
+                // large overlay SVG can't absorb sibling content even when
+                // its bbox spans most of the slide.
+                if (svgPathCount > 0 && svgPathCount <= __SVG_NATIVE_PATH_BUDGET__) {
                     const svgRect = el.getBoundingClientRect();
                     svgShapes = [];
                     for (const s of allShapes) {
@@ -374,6 +386,11 @@ WALKER_JS = r"""
     return out;
 }
 """
+
+
+WALKER_JS = _WALKER_JS_TEMPLATE.replace(
+    "__SVG_NATIVE_PATH_BUDGET__", str(SVG_NATIVE_PATH_BUDGET)
+)
 
 
 async def walk(page: Page) -> list[DomElement]:

--- a/slidify/svg_path.py
+++ b/slidify/svg_path.py
@@ -12,15 +12,13 @@ Supported commands:
     S / s   smooth cubic Bezier (reflected first control)
     Q / q   quadratic Bezier
     T / t   smooth quadratic Bezier (reflected control)
+    A / a   elliptical arc (approximated as up to four cubic Beziers)
     Z / z   close
-
-Arc commands (A / a) are not supported; we fall back to a straight line
-to the arc endpoint. Implementing the SVG arc → cubic conversion is out
-of scope for this module.
 """
 
 from __future__ import annotations
 
+import math
 import re
 
 # Public command tuple shapes:
@@ -42,6 +40,138 @@ def _tokenize(d: str) -> list[str]:
 def _take_floats(tokens: list[str], i: int, n: int) -> tuple[list[float], int]:
     vals = [float(tokens[i + k]) for k in range(n)]
     return vals, i + n
+
+
+def _arc_to_cubics(
+    x1: float,
+    y1: float,
+    rx: float,
+    ry: float,
+    phi_deg: float,
+    large_arc: bool,
+    sweep: bool,
+    x2: float,
+    y2: float,
+) -> list[tuple[float, float, float, float, float, float]]:
+    """Convert an SVG endpoint-form arc into cubic Bezier segments.
+
+    Returns a list of (c1x, c1y, c2x, c2y, x, y) absolute control/end points,
+    each spanning at most pi/2 radians for good circular approximation.
+    Per the SVG spec:
+      - if (x1, y1) == (x2, y2): the arc is omitted entirely (empty list).
+      - if rx == 0 or ry == 0: degenerate to a straight line, returned as a
+        single zero-curvature cubic (control points on the chord) so callers
+        can keep emitting cubicBezTo uniformly.
+    """
+    # Endpoints coincide → no arc.
+    if x1 == x2 and y1 == y2:
+        return []
+
+    rx = abs(rx)
+    ry = abs(ry)
+    if rx == 0.0 or ry == 0.0:
+        # Spec: treat as a line. Emit a degenerate cubic so the caller path
+        # stays consistent (control points on the chord).
+        return [(x1, y1, x2, y2, x2, y2)]
+
+    phi = math.radians(phi_deg)
+    cos_phi = math.cos(phi)
+    sin_phi = math.sin(phi)
+
+    # Step 1: compute (x1', y1') in the rotated/translated frame.
+    dx = (x1 - x2) / 2.0
+    dy = (y1 - y2) / 2.0
+    x1p = cos_phi * dx + sin_phi * dy
+    y1p = -sin_phi * dx + cos_phi * dy
+
+    # Out-of-range radii correction (F.6.6.2).
+    lam = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry)
+    if lam > 1.0:
+        s = math.sqrt(lam)
+        rx *= s
+        ry *= s
+
+    # Step 2: compute (cx', cy').
+    rx2 = rx * rx
+    ry2 = ry * ry
+    x1p2 = x1p * x1p
+    y1p2 = y1p * y1p
+    num = rx2 * ry2 - rx2 * y1p2 - ry2 * x1p2
+    den = rx2 * y1p2 + ry2 * x1p2
+    factor_sq = max(0.0, num / den) if den != 0.0 else 0.0
+    factor = math.sqrt(factor_sq)
+    if large_arc == sweep:
+        factor = -factor
+    cxp = factor * (rx * y1p) / ry
+    cyp = factor * -(ry * x1p) / rx
+
+    # Step 3: (cx, cy) in the original frame.
+    cx = cos_phi * cxp - sin_phi * cyp + (x1 + x2) / 2.0
+    cy = sin_phi * cxp + cos_phi * cyp + (y1 + y2) / 2.0
+
+    # Step 4: start angle and sweep delta.
+    def _angle(ux: float, uy: float, vx: float, vy: float) -> float:
+        n = math.hypot(ux, uy) * math.hypot(vx, vy)
+        if n == 0.0:
+            return 0.0
+        c = max(-1.0, min(1.0, (ux * vx + uy * vy) / n))
+        a = math.acos(c)
+        if ux * vy - uy * vx < 0.0:
+            a = -a
+        return a
+
+    sx = (x1p - cxp) / rx
+    sy = (y1p - cyp) / ry
+    ex = (-x1p - cxp) / rx
+    ey = (-y1p - cyp) / ry
+    theta1 = _angle(1.0, 0.0, sx, sy)
+    delta = _angle(sx, sy, ex, ey)
+    if not sweep and delta > 0.0:
+        delta -= 2.0 * math.pi
+    elif sweep and delta < 0.0:
+        delta += 2.0 * math.pi
+
+    # Split into segments of at most pi/2 for accurate approximation.
+    n_segments = max(1, int(math.ceil(abs(delta) / (math.pi / 2.0))))
+    seg_delta = delta / n_segments
+
+    segments: list[tuple[float, float, float, float, float, float]] = []
+    t = math.tan(seg_delta / 2.0)
+    alpha = math.sin(seg_delta) * (math.sqrt(4.0 + 3.0 * t * t) - 1.0) / 3.0
+
+    def _to_world(px: float, py: float) -> tuple[float, float]:
+        return (
+            cos_phi * px - sin_phi * py + cx,
+            sin_phi * px + cos_phi * py + cy,
+        )
+
+    for k in range(n_segments):
+        a0 = theta1 + k * seg_delta
+        a1 = a0 + seg_delta
+
+        cos_a0 = math.cos(a0)
+        sin_a0 = math.sin(a0)
+        cos_a1 = math.cos(a1)
+        sin_a1 = math.sin(a1)
+
+        # Endpoints in unrotated ellipse frame.
+        p0x = rx * cos_a0
+        p0y = ry * sin_a0
+        p1x = rx * cos_a1
+        p1y = ry * sin_a1
+
+        # Control points using the standard cubic-arc approximation.
+        c1x_pre = p0x - alpha * rx * sin_a0
+        c1y_pre = p0y + alpha * ry * cos_a0
+        c2x_pre = p1x + alpha * rx * sin_a1
+        c2y_pre = p1y - alpha * ry * cos_a1
+
+        c1 = _to_world(c1x_pre, c1y_pre)
+        c2 = _to_world(c2x_pre, c2y_pre)
+        end = _to_world(p1x, p1y)
+        segments.append((c1[0], c1[1], c2[0], c2[1], end[0], end[1]))
+
+    return segments
 
 
 def parse_path(d: str) -> list[PathCommand]:
@@ -179,14 +309,16 @@ def parse_path(d: str) -> list[PathCommand]:
             last_cubic_ctrl = None
 
         elif cmd in ("A", "a"):
-            # Arcs unsupported — fall back to a straight line to the endpoint.
-            # Arc payload is: rx ry x-axis-rotation large-arc sweep x y.
-            (_rx, _ry, _rot, _laf, _sf, x, y), i = _take_floats(tokens, i, 7)
+            # Arc payload: rx ry x-axis-rotation large-arc sweep x y.
+            (rx, ry, rot, laf, sf, x, y), i = _take_floats(tokens, i, 7)
             if cmd == "a":
                 x += cur_x
                 y += cur_y
+            for seg in _arc_to_cubics(
+                cur_x, cur_y, rx, ry, rot, laf != 0.0, sf != 0.0, x, y
+            ):
+                commands.append(("cubicBezTo", *seg))
             cur_x, cur_y = x, y
-            commands.append(("lineTo", x, y))
             last_cubic_ctrl = None
             last_quad_ctrl = None
 

--- a/slidify/svg_shapes.py
+++ b/slidify/svg_shapes.py
@@ -1,11 +1,10 @@
 """Translate simple SVG primitives to native PPTX shapes.
 
-Supports `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polygon>`, `<polyline>`.
-Single `<path>` elements are *not* translated (would need a real path parser);
-they fall back to raster.
+Supports `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polygon>`, `<polyline>`,
+`<path>` (via slidify.svg_path), and `<text>`.
 
 Coordinates are in SVG userspace; we map them into the SVG element's viewport
-bounding box on the slide.
+bounding box on the slide, honoring `viewBox` and `preserveAspectRatio`.
 """
 
 from __future__ import annotations
@@ -37,14 +36,68 @@ class _Mapping:
 
 
 def _build_mapping(svg_rect: dict) -> _Mapping:
-    """SVG userspace assumed equal to viewport pixels (the common case for
-    inline SVG without a viewBox). For SVGs *with* a viewBox we'd need to
-    parse it; we accept the simplification for v1."""
+    """Map SVG userspace into a sub-rect of the slide.
+
+    If the SVG has no `viewBox`, userspace == viewport pixels (1:1).
+    Otherwise the viewBox `(min-x, min-y, vb-w, vb-h)` is mapped into the
+    rendered viewport `(x, y, w, h)`, honoring `preserveAspectRatio` (the
+    default `xMidYMid meet` keeps aspect and centers; `none` stretches).
+    """
+    rect_x = svg_rect.get("x", 0.0) or 0.0
+    rect_y = svg_rect.get("y", 0.0) or 0.0
+    rect_w = svg_rect.get("w", 0.0) or 0.0
+    rect_h = svg_rect.get("h", 0.0) or 0.0
+
+    vb = svg_rect.get("viewBox")
+    if not vb or rect_w <= 0 or rect_h <= 0:
+        return _Mapping(rect_x, rect_y, 1.0, 1.0)
+
+    try:
+        min_x, min_y, vb_w, vb_h = (float(v) for v in vb)
+    except (TypeError, ValueError):
+        return _Mapping(rect_x, rect_y, 1.0, 1.0)
+    if vb_w <= 0 or vb_h <= 0:
+        return _Mapping(rect_x, rect_y, 1.0, 1.0)
+
+    par = (svg_rect.get("preserveAspectRatio") or "xMidYMid meet").strip().lower()
+    parts = par.split()
+    align = parts[0] if parts else "xmidymid"
+    meet_or_slice = parts[1] if len(parts) > 1 else "meet"
+
+    if align == "none":
+        scale_x = rect_w / vb_w
+        scale_y = rect_h / vb_h
+        return _Mapping(
+            rect_x - min_x * scale_x,
+            rect_y - min_y * scale_y,
+            scale_x,
+            scale_y,
+        )
+
+    sx = rect_w / vb_w
+    sy = rect_h / vb_h
+    scale = min(sx, sy) if meet_or_slice != "slice" else max(sx, sy)
+    extra_x = rect_w - vb_w * scale
+    extra_y = rect_h - vb_h * scale
+
+    if "xmin" in align:
+        ox = 0.0
+    elif "xmax" in align:
+        ox = extra_x
+    else:
+        ox = extra_x / 2.0
+    if "ymin" in align:
+        oy = 0.0
+    elif "ymax" in align:
+        oy = extra_y
+    else:
+        oy = extra_y / 2.0
+
     return _Mapping(
-        svg_origin_x=svg_rect["x"],
-        svg_origin_y=svg_rect["y"],
-        scale_x=1.0,
-        scale_y=1.0,
+        rect_x + ox - min_x * scale,
+        rect_y + oy - min_y * scale,
+        scale,
+        scale,
     )
 
 

--- a/tests/fixtures/svg_quality_stress.html
+++ b/tests/fixtures/svg_quality_stress.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>SVG quality stress</title>
+<style>
+  html, body { margin: 0; padding: 0; }
+  body {
+    width: 1280px;
+    height: 720px;
+    font-family: 'Inter', sans-serif;
+    background: #0f172a;
+    color: #f1f5f9;
+    padding: 32px;
+    box-sizing: border-box;
+  }
+  h1 { margin: 0 0 16px; font-size: 24px; }
+  .row { display: flex; gap: 32px; align-items: flex-start; }
+  .panel { background: #1e293b; padding: 16px; border-radius: 8px; }
+  .panel h2 { margin: 0 0 8px; font-size: 14px; color: #94a3b8; font-weight: 600; }
+</style>
+</head>
+<body>
+  <h1>SVG quality stress test</h1>
+  <div class="row">
+
+    <!-- A. DONUT CHART using arc (A) commands -- exercises Phase 1 -->
+    <div class="panel">
+      <h2>Donut (arc commands)</h2>
+      <svg width="200" height="200" viewBox="0 0 100 100">
+        <!-- Four 90° wedges anchored at (50, 50) with outer radius 40 -->
+        <path d="M 50 50 L 90 50 A 40 40 0 0 1 50 90 Z" fill="#0ea5e9"/>
+        <path d="M 50 50 L 50 90 A 40 40 0 0 1 10 50 Z" fill="#22c55e"/>
+        <path d="M 50 50 L 10 50 A 40 40 0 0 1 50 10 Z" fill="#eab308"/>
+        <path d="M 50 50 L 50 10 A 40 40 0 0 1 90 50 Z" fill="#ef4444"/>
+        <!-- Inner hole punched as a cubic-only path so we still touch
+             the original code path as well -->
+        <circle cx="50" cy="50" r="18" fill="#0f172a"/>
+      </svg>
+    </div>
+
+    <!-- B. ICON with viewBox at non-1:1 scale -- exercises Phase 2 -->
+    <div class="panel">
+      <h2>Icon (viewBox 24, rendered 80)</h2>
+      <svg width="80" height="80" viewBox="0 0 24 24">
+        <!-- A circle at (12, 12) with r=10 must render centered in the
+             80x80 box. Without the viewBox fix, the circle landed near
+             the top-left corner (radius 10 of a 1280-wide canvas). -->
+        <circle cx="12" cy="12" r="10" fill="none"
+                stroke="#38bdf8" stroke-width="2"/>
+        <path d="M 8 12 L 11 15 L 16 9" fill="none"
+              stroke="#38bdf8" stroke-width="2"/>
+      </svg>
+    </div>
+
+    <!-- C. DENSE BAR CHART -- exercises Phase 3 (path-count > 30) -->
+    <div class="panel">
+      <h2>Dense bar chart (60+ primitives)</h2>
+      <svg width="600" height="200" viewBox="0 0 600 200">
+        <!-- Y-axis -->
+        <line x1="40" y1="10" x2="40" y2="180"
+              stroke="#475569" stroke-width="1"/>
+        <!-- X-axis -->
+        <line x1="40" y1="180" x2="590" y2="180"
+              stroke="#475569" stroke-width="1"/>
+        <!-- 11 horizontal gridlines -->
+        <line x1="40" y1="20"  x2="590" y2="20"  stroke="#334155" stroke-width="0.5"/>
+        <line x1="40" y1="40"  x2="590" y2="40"  stroke="#334155" stroke-width="0.5"/>
+        <line x1="40" y1="60"  x2="590" y2="60"  stroke="#334155" stroke-width="0.5"/>
+        <line x1="40" y1="80"  x2="590" y2="80"  stroke="#334155" stroke-width="0.5"/>
+        <line x1="40" y1="100" x2="590" y2="100" stroke="#334155" stroke-width="0.5"/>
+        <line x1="40" y1="120" x2="590" y2="120" stroke="#334155" stroke-width="0.5"/>
+        <line x1="40" y1="140" x2="590" y2="140" stroke="#334155" stroke-width="0.5"/>
+        <line x1="40" y1="160" x2="590" y2="160" stroke="#334155" stroke-width="0.5"/>
+        <!-- 40 bars -->
+        <rect x="44"  y="60"  width="12" height="120" fill="#0ea5e9"/>
+        <rect x="58"  y="80"  width="12" height="100" fill="#0ea5e9"/>
+        <rect x="72"  y="50"  width="12" height="130" fill="#0ea5e9"/>
+        <rect x="86"  y="100" width="12" height="80"  fill="#0ea5e9"/>
+        <rect x="100" y="40"  width="12" height="140" fill="#0ea5e9"/>
+        <rect x="114" y="70"  width="12" height="110" fill="#0ea5e9"/>
+        <rect x="128" y="55"  width="12" height="125" fill="#0ea5e9"/>
+        <rect x="142" y="90"  width="12" height="90"  fill="#0ea5e9"/>
+        <rect x="156" y="35"  width="12" height="145" fill="#0ea5e9"/>
+        <rect x="170" y="75"  width="12" height="105" fill="#0ea5e9"/>
+        <rect x="184" y="65"  width="12" height="115" fill="#0ea5e9"/>
+        <rect x="198" y="95"  width="12" height="85"  fill="#0ea5e9"/>
+        <rect x="212" y="45"  width="12" height="135" fill="#0ea5e9"/>
+        <rect x="226" y="85"  width="12" height="95"  fill="#0ea5e9"/>
+        <rect x="240" y="55"  width="12" height="125" fill="#0ea5e9"/>
+        <rect x="254" y="105" width="12" height="75"  fill="#0ea5e9"/>
+        <rect x="268" y="50"  width="12" height="130" fill="#0ea5e9"/>
+        <rect x="282" y="80"  width="12" height="100" fill="#0ea5e9"/>
+        <rect x="296" y="60"  width="12" height="120" fill="#0ea5e9"/>
+        <rect x="310" y="100" width="12" height="80"  fill="#0ea5e9"/>
+        <rect x="324" y="40"  width="12" height="140" fill="#22c55e"/>
+        <rect x="338" y="70"  width="12" height="110" fill="#22c55e"/>
+        <rect x="352" y="55"  width="12" height="125" fill="#22c55e"/>
+        <rect x="366" y="90"  width="12" height="90"  fill="#22c55e"/>
+        <rect x="380" y="35"  width="12" height="145" fill="#22c55e"/>
+        <rect x="394" y="75"  width="12" height="105" fill="#22c55e"/>
+        <rect x="408" y="65"  width="12" height="115" fill="#22c55e"/>
+        <rect x="422" y="95"  width="12" height="85"  fill="#22c55e"/>
+        <rect x="436" y="45"  width="12" height="135" fill="#22c55e"/>
+        <rect x="450" y="85"  width="12" height="95"  fill="#22c55e"/>
+        <rect x="464" y="55"  width="12" height="125" fill="#22c55e"/>
+        <rect x="478" y="105" width="12" height="75"  fill="#22c55e"/>
+        <rect x="492" y="50"  width="12" height="130" fill="#22c55e"/>
+        <rect x="506" y="80"  width="12" height="100" fill="#22c55e"/>
+        <rect x="520" y="60"  width="12" height="120" fill="#22c55e"/>
+        <rect x="534" y="100" width="12" height="80"  fill="#22c55e"/>
+        <rect x="548" y="40"  width="12" height="140" fill="#22c55e"/>
+        <rect x="562" y="70"  width="12" height="110" fill="#22c55e"/>
+        <rect x="576" y="55"  width="12" height="125" fill="#22c55e"/>
+        <rect x="588" y="90"  width="2"  height="90"  fill="#22c55e"/>
+        <!-- 5 axis labels -->
+        <text x="20" y="184" font-size="9" fill="#94a3b8">0</text>
+        <text x="20" y="144" font-size="9" fill="#94a3b8">25</text>
+        <text x="20" y="104" font-size="9" fill="#94a3b8">50</text>
+        <text x="20" y="64"  font-size="9" fill="#94a3b8">75</text>
+        <text x="20" y="24"  font-size="9" fill="#94a3b8">100</text>
+      </svg>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/integration/test_svg_quality_stress.py
+++ b/tests/integration/test_svg_quality_stress.py
@@ -1,0 +1,97 @@
+"""End-to-end integration test for SVG quality features.
+
+Exercises the three improvements landed under the "slideshow quality"
+arc:
+  1. SVG path arcs (A/a) translate to cubic Beziers — the donut wedges
+     in the fixture use M+L+A+Z, so they only emit non-trivially if the
+     arc handler does real work.
+  2. viewBox + preserveAspectRatio — a checkmark icon defined in a
+     `viewBox="0 0 24 24"` but rendered into an 80×80 box should land
+     centered with circle radius ~33 px (instead of radius 10 in the
+     wrong corner).
+  3. Path-count threshold (≥ 200) — the dense bar chart contains 60+
+     SVG primitives in one element, which previously rasterized whole.
+
+The test inspects the produced PPTX to confirm:
+  - The slide produces native-translated content (native_area_ratio == 1.0).
+  - At least 4 custGeom freeforms appear (the donut wedges).
+  - At least 60 native shapes total exist (the dense chart didn't raster).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pptx import Presentation
+
+from slidify.api import ConversionConfig, convert
+
+A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "svg_quality_stress.html"
+
+
+def _count_custgeom(slide) -> int:
+    """Number of shapes with `<a:custGeom>` — i.e., paths emitted natively."""
+    n = 0
+    for shape in slide.shapes:
+        sp_pr = getattr(shape._element, "spPr", None)
+        if sp_pr is None:
+            continue
+        if sp_pr.find(f"{{{A_NS}}}custGeom") is not None:
+            n += 1
+    return n
+
+
+@pytest.mark.asyncio
+async def test_svg_quality_fixture_emits_natively(tmp_path: Path):
+    pptx_path = tmp_path / "stress.pptx"
+    cfg = ConversionConfig(run_oracle=False, run_tier3=False)
+    result = await convert(FIXTURE.read_text(encoding="utf-8"), pptx_path, cfg)
+
+    assert pptx_path.exists() and pptx_path.stat().st_size > 0
+    assert result.n_slides == 1
+    # All three SVGs should land on the native path; nothing falls back to
+    # raster. Pre-changes, the dense bar chart alone (>30 prims) forced
+    # whole-region raster.
+    assert result.native_area_ratio == 1.0, (
+        f"expected fully-native emission, got {result.native_area_ratio}"
+    )
+
+    prs = Presentation(pptx_path)
+    slide = prs.slides[0]
+
+    # Donut: four <path> elements with arc commands → four custGeom shapes.
+    # If A/a still degraded to lineTo, the wedges would emit but as straight
+    # triangles; we'd still see custGeom, so we additionally check that the
+    # cubicBezTo count on those shapes is high.
+    custgeom_count = _count_custgeom(slide)
+    assert custgeom_count >= 4, (
+        f"expected ≥4 custGeom freeforms (donut wedges), got {custgeom_count}"
+    )
+
+    # Sum cubicBezTo elements across all custGeom shapes. Each donut wedge
+    # contributes ≥1 cubic from the 90° arc; the inner hole circle adds
+    # zero (it's a preset oval). So we expect ≥4 cubicBezTo elements
+    # solely from the arc handler.
+    cubic_count = 0
+    for shape in slide.shapes:
+        sp_pr = getattr(shape._element, "spPr", None)
+        if sp_pr is None:
+            continue
+        cg = sp_pr.find(f"{{{A_NS}}}custGeom")
+        if cg is None:
+            continue
+        cubic_count += len(cg.findall(f".//{{{A_NS}}}cubicBezTo"))
+    assert cubic_count >= 4, (
+        f"expected ≥4 cubicBezTo from donut arcs; got {cubic_count}. "
+        "If 0, arcs are still falling through to lineTo."
+    )
+
+    # Dense chart: 60+ primitives must produce ≥60 native shapes total.
+    # Prior to bumping SVG_NATIVE_PATH_BUDGET above 30, the entire chart
+    # rasterized to a single picture and shape count plummeted.
+    assert len(slide.shapes) >= 60, (
+        f"expected ≥60 native shapes total (dense chart should not raster); "
+        f"got {len(slide.shapes)}"
+    )

--- a/tests/unit/test_svg_path.py
+++ b/tests/unit/test_svg_path.py
@@ -1,8 +1,10 @@
-"""Tests for SVG path curve commands (C/c, S/s, Q/q, T/t) in slidify.svg_shapes."""
+"""Tests for SVG path curve commands (C/c, S/s, Q/q, T/t, A/a) in slidify.svg_shapes."""
 
 from __future__ import annotations
 
-from slidify.svg_path import parse_path
+import math
+
+from slidify.svg_path import commands_to_path_xml, parse_path
 
 
 def test_cubic_bezier_absolute():
@@ -43,3 +45,141 @@ def test_relative_cubic_advances_current_point():
         ("moveTo", 10.0, 10.0),
         ("cubicBezTo", 20.0, 20.0, 40.0, 20.0, 50.0, 10.0),
     ]
+
+
+# --- Arc commands (A / a) ---------------------------------------------------
+
+
+def _bezier_point(c1, c2, p0, p1, t):
+    """Evaluate a cubic Bezier at t given start p0 and end p1."""
+    u = 1.0 - t
+    return (
+        u**3 * p0[0] + 3 * u**2 * t * c1[0] + 3 * u * t**2 * c2[0] + t**3 * p1[0],
+        u**3 * p0[1] + 3 * u**2 * t * c1[1] + 3 * u * t**2 * c2[1] + t**3 * p1[1],
+    )
+
+
+def _walk_cubics(cmds):
+    """Yield (p0, c1, c2, p1) for every cubic in the command list."""
+    cur = (0.0, 0.0)
+    for cmd in cmds:
+        op = cmd[0]
+        if op == "moveTo":
+            cur = (cmd[1], cmd[2])
+        elif op == "lineTo":
+            cur = (cmd[1], cmd[2])
+        elif op == "cubicBezTo":
+            _, c1x, c1y, c2x, c2y, x, y = cmd
+            yield (cur, (c1x, c1y), (c2x, c2y), (x, y))
+            cur = (x, y)
+        elif op == "quadBezTo":
+            cur = (cmd[3], cmd[4])
+
+
+def test_arc_quarter_circle_emits_one_cubic():
+    """`M 100 0 A 100 100 0 0 0 0 100` traces a 90° CCW arc from (100,0)
+    to (0,100) on the unit circle of radius 100. One cubic suffices."""
+    cmds = parse_path("M 100 0 A 100 100 0 0 0 0 100")
+    cubics = list(_walk_cubics(cmds))
+    assert len(cubics) == 1
+    p0, _, _, p1 = cubics[0]
+    assert p0 == (100.0, 0.0)
+    assert math.isclose(p1[0], 0.0, abs_tol=1e-6)
+    assert math.isclose(p1[1], 100.0, abs_tol=1e-6)
+
+
+def test_arc_quarter_circle_midpoint_on_circle():
+    """The midpoint of the cubic approximation of a 90° arc centered at the
+    origin should lie within ~0.03% of the true circle of radius 100.
+    `sweep=1` selects the arc whose center is at the origin (bulging away
+    from the origin to ~(70.7, 70.7))."""
+    cmds = parse_path("M 100 0 A 100 100 0 0 1 0 100")
+    cubics = list(_walk_cubics(cmds))
+    assert len(cubics) == 1
+    p0, c1, c2, p1 = cubics[0]
+    mid = _bezier_point(c1, c2, p0, p1, 0.5)
+    radius = math.hypot(mid[0], mid[1])
+    # Cubic approximation of a 90° arc has ~0.03% peak normal error; the
+    # parametric t=0.5 sample isn't the arc midpoint so the radial deviation
+    # we measure here is a few tenths of a unit.
+    assert abs(radius - 100.0) < 0.5
+
+
+def test_arc_full_circle_splits_into_four_segments():
+    """A full circle (start == end with large-arc) is encoded as two
+    half-arcs in SVG. Each half-arc must split into 2 cubic segments
+    (≤ π/2 each), giving 4 cubics total."""
+    cmds = parse_path("M 100 0 A 100 100 0 1 0 -100 0 A 100 100 0 1 0 100 0")
+    cubics = list(_walk_cubics(cmds))
+    assert len(cubics) == 4
+    # Every cubic endpoint sits on the radius-100 circle (within tolerance).
+    for _, _, _, p1 in cubics:
+        r = math.hypot(p1[0], p1[1])
+        assert abs(r - 100.0) < 0.5
+
+
+def test_arc_zero_radius_falls_back_to_line():
+    """Per SVG F.6.2, an arc with rx=0 or ry=0 collapses to a straight line.
+    We emit a degenerate cubic (control points on the chord) so the endpoint
+    is reached without curvature."""
+    cmds = parse_path("M 0 0 A 0 50 0 0 0 100 0")
+    assert len(cmds) == 2
+    assert cmds[0] == ("moveTo", 0.0, 0.0)
+    assert cmds[1][0] == "cubicBezTo"
+    p0 = (0.0, 0.0)
+    _, c1x, c1y, c2x, c2y, x, y = cmds[1]
+    # All cubic samples lie on the y=0 chord.
+    for t in (0.25, 0.5, 0.75):
+        _bx, by = _bezier_point((c1x, c1y), (c2x, c2y), p0, (x, y), t)
+        assert math.isclose(by, 0.0, abs_tol=1e-9)
+    assert math.isclose(x, 100.0, abs_tol=1e-9)
+
+
+def test_arc_coincident_endpoints_omits_arc():
+    """SVG spec: when the arc's endpoints are equal, the arc is treated as
+    nonexistent. Subsequent commands continue from the same point."""
+    cmds = parse_path("M 0 0 A 50 50 0 0 0 0 0 L 100 0")
+    assert cmds == [
+        ("moveTo", 0.0, 0.0),
+        ("lineTo", 100.0, 0.0),
+    ]
+
+
+def test_arc_sweep_flag_picks_opposite_centers():
+    """The two small arcs from (100,0) to (0,100) on radius 100 share their
+    chord (midpoint (50,50)) but bulge to opposite sides:
+      - sweep=0 selects the arc whose center is at (100,100); the midpoint
+        bulges *toward* the origin to ~(29.3, 29.3).
+      - sweep=1 selects the arc whose center is at (0,0); the midpoint
+        bulges *away* from the origin to ~(70.7, 70.7)."""
+    p0, c1, c2, p1 = next(_walk_cubics(parse_path("M 100 0 A 100 100 0 0 0 0 100")))
+    mid_sweep0 = _bezier_point(c1, c2, p0, p1, 0.5)
+    p0, c1, c2, p1 = next(_walk_cubics(parse_path("M 100 0 A 100 100 0 0 1 0 100")))
+    mid_sweep1 = _bezier_point(c1, c2, p0, p1, 0.5)
+    # Both midpoints are in (+, +); they differ by which side of the chord
+    # x + y = 100 they lie on.
+    assert mid_sweep0[0] + mid_sweep0[1] < 100  # toward the origin
+    assert mid_sweep1[0] + mid_sweep1[1] > 100  # away from the origin
+    # sweep=1 midpoint sits ~radius 100 from origin (center is at origin).
+    assert abs(math.hypot(*mid_sweep1) - 100.0) < 0.5
+
+
+def test_arc_relative_advances_current_point():
+    """Lower-case `a` is relative to the current point."""
+    cmds = parse_path("M 100 50 a 50 50 0 0 0 -50 50")
+    cubics = list(_walk_cubics(cmds))
+    assert len(cubics) == 1
+    p0, _, _, p1 = cubics[0]
+    assert p0 == (100.0, 50.0)
+    assert math.isclose(p1[0], 50.0, abs_tol=1e-6)
+    assert math.isclose(p1[1], 100.0, abs_tol=1e-6)
+
+
+def test_arc_emits_cubicbezto_in_xml():
+    """The path-XML emitter must surface arc segments as `<a:cubicBezTo>`
+    elements (not lnTo, the previous fallback behavior)."""
+    cmds = parse_path("M 100 0 A 100 100 0 0 0 0 100")
+    xml = commands_to_path_xml(cmds, width=100, height=100)
+    assert "<a:cubicBezTo>" in xml
+    # No lineTo from the arc itself (the moveTo doesn't emit lnTo either).
+    assert "<a:lnTo>" not in xml

--- a/tests/unit/test_svg_shapes.py
+++ b/tests/unit/test_svg_shapes.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pptx import Presentation
 from pptx.util import Emu
 
-from slidify.svg_shapes import emit_svg_shapes
+from slidify.svg_shapes import _build_mapping, emit_svg_shapes
 
 A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
 
@@ -123,6 +123,111 @@ def test_fill_opacity_one_does_not_emit_alpha():
     srgb = solid.find(f"{{{A_NS}}}srgbClr") if solid is not None else None
     if srgb is not None:
         assert srgb.find(f"{{{A_NS}}}alpha") is None
+
+
+# --- _build_mapping (viewBox + preserveAspectRatio) -----------------------
+
+
+def test_mapping_no_viewbox_is_identity():
+    """SVGs without a viewBox have userspace == viewport pixels (1:1)."""
+    m = _build_mapping({"x": 100, "y": 50, "w": 800, "h": 600})
+    assert m.scale_x == 1.0 and m.scale_y == 1.0
+    assert m.x(0) == 100 and m.y(0) == 50
+    assert m.x(40) == 140 and m.y(60) == 110
+
+
+def test_mapping_uniform_viewbox_scales_uniformly():
+    """viewBox `0 0 100 100` rendered at 200×200 → 2× uniform scale."""
+    m = _build_mapping(
+        {"x": 0, "y": 0, "w": 200, "h": 200, "viewBox": [0, 0, 100, 100]}
+    )
+    assert m.scale_x == 2.0 and m.scale_y == 2.0
+    assert m.x(50) == 100 and m.y(50) == 100
+
+
+def test_mapping_default_preserve_aspect_meet_centers_on_wide_viewport():
+    """Default preserveAspectRatio is `xMidYMid meet`. A square viewBox
+    rendered into a wider viewport keeps the smaller scale and centers
+    horizontally — slight letterboxing on the sides."""
+    # viewBox 100×100 → viewport 200×100. scale = min(2, 1) = 1.
+    # Extra width = 200 - 100*1 = 100, centered → ox = 50.
+    m = _build_mapping(
+        {"x": 0, "y": 0, "w": 200, "h": 100, "viewBox": [0, 0, 100, 100]}
+    )
+    assert m.scale_x == 1.0 and m.scale_y == 1.0
+    assert m.x(0) == 50 and m.y(0) == 0
+    assert m.x(100) == 150 and m.y(100) == 100
+
+
+def test_mapping_preserve_aspect_none_stretches_independently():
+    """preserveAspectRatio="none" stretches each axis independently."""
+    m = _build_mapping(
+        {
+            "x": 0,
+            "y": 0,
+            "w": 200,
+            "h": 100,
+            "viewBox": [0, 0, 100, 100],
+            "preserveAspectRatio": "none",
+        }
+    )
+    assert m.scale_x == 2.0 and m.scale_y == 1.0
+    assert m.x(50) == 100 and m.y(50) == 50
+
+
+def test_mapping_viewbox_with_nonzero_origin_translates_correctly():
+    """A viewBox `-10 -20 100 100` shifts userspace: a userspace point
+    (-10, -20) maps to the viewport origin."""
+    m = _build_mapping(
+        {"x": 0, "y": 0, "w": 100, "h": 100, "viewBox": [-10, -20, 100, 100]}
+    )
+    assert m.x(-10) == 0 and m.y(-20) == 0
+    assert m.x(0) == 10 and m.y(0) == 20
+
+
+def test_mapping_xminymin_meet_anchors_top_left():
+    """preserveAspectRatio="xMinYMin meet" keeps the smaller scale but
+    anchors at the top-left instead of centering."""
+    m = _build_mapping(
+        {
+            "x": 0,
+            "y": 0,
+            "w": 200,
+            "h": 100,
+            "viewBox": [0, 0, 100, 100],
+            "preserveAspectRatio": "xMinYMin meet",
+        }
+    )
+    assert m.scale_x == 1.0
+    assert m.x(0) == 0  # no horizontal centering offset
+    assert m.x(100) == 100
+
+
+def test_mapping_offset_viewport_with_viewbox():
+    """SVGs are usually placed at non-zero positions on the slide; the
+    viewport offset must compose correctly with the viewBox-derived scale."""
+    m = _build_mapping(
+        {"x": 64, "y": 32, "w": 640, "h": 360, "viewBox": [0, 0, 100, 100]}
+    )
+    # Square viewBox in 640×360 viewport, default meet → scale = min(6.4, 3.6) = 3.6.
+    # Extra width = 640 - 100*3.6 = 280, centered → ox = 140.
+    assert m.scale_x == 3.6 and m.scale_y == 3.6
+    assert m.x(0) == 64 + 140
+    assert m.y(0) == 32
+
+
+def test_mapping_invalid_viewbox_falls_back_to_identity():
+    """Malformed viewBox (zero/negative dims, wrong arity) silently degrades
+    to 1:1 mapping rather than producing NaN/division-by-zero coords."""
+    assert _build_mapping(
+        {"x": 0, "y": 0, "w": 100, "h": 100, "viewBox": [0, 0, 0, 100]}
+    ).scale_x == 1.0
+    assert _build_mapping(
+        {"x": 0, "y": 0, "w": 100, "h": 100, "viewBox": [0, 0, 100]}
+    ).scale_x == 1.0
+    assert _build_mapping(
+        {"x": 0, "y": 0, "w": 0, "h": 100, "viewBox": [0, 0, 100, 100]}
+    ).scale_x == 1.0
 
 
 def test_stroke_opacity_emits_alpha_on_line_color():

--- a/tests/unit/test_tier1_svg_threshold.py
+++ b/tests/unit/test_tier1_svg_threshold.py
@@ -1,0 +1,66 @@
+"""Regression tests for the SVG complexity threshold in classifier.tier1.
+
+Two invariants:
+  1. The threshold lives in `slidify.dom_walker.SVG_NATIVE_PATH_BUDGET` and
+     `_has_complex_svg` reads from the same constant. A divergence creates
+     a "dead band" where the walker drops geometry but the classifier still
+     routes the unit to the native emitter (which then emits an empty shell).
+  2. SVGs at the boundary go native; one shape past it goes raster.
+"""
+
+from __future__ import annotations
+
+from slidify.classifier.tier1 import _has_complex_svg
+from slidify.dom_walker import SVG_NATIVE_PATH_BUDGET, WALKER_JS
+from slidify.models import BoundingBox, DomElement, UnitKind, VisualUnit
+
+
+def _svg_unit(path_count: int) -> VisualUnit:
+    bbox = BoundingBox(x=0, y=0, w=400, h=300)
+    el = DomElement(
+        id=1,
+        parent_id=None,
+        depth=0,
+        tag="svg",
+        bbox=bbox,
+        is_svg=True,
+        svg_path_count=path_count,
+    )
+    return VisualUnit(id="u_svg", kind=UnitKind.Generic, bbox=bbox, elements=[el])
+
+
+def test_threshold_exceeded_marks_unit_complex():
+    """One shape past the budget routes to the raster path."""
+    assert _has_complex_svg(_svg_unit(SVG_NATIVE_PATH_BUDGET + 1)) is True
+
+
+def test_threshold_at_budget_stays_native():
+    """An SVG with exactly the budget's worth of shapes should still go
+    native — `>` not `>=` is the boundary."""
+    assert _has_complex_svg(_svg_unit(SVG_NATIVE_PATH_BUDGET)) is False
+
+
+def test_well_below_threshold_is_not_complex():
+    """A small icon (≤ 10 primitives) is unambiguously native-eligible."""
+    assert _has_complex_svg(_svg_unit(10)) is False
+
+
+def test_zero_path_svg_is_not_complex():
+    """A degenerate SVG with zero captured primitives isn't 'complex' per
+    this rule — a different rule decides whether to skip it entirely."""
+    assert _has_complex_svg(_svg_unit(0)) is False
+
+
+def test_walker_js_was_substituted_with_python_constant():
+    """The JS template uses `__SVG_NATIVE_PATH_BUDGET__` as a sentinel;
+    the runtime `WALKER_JS` must contain the resolved integer instead.
+    Catches accidental edits to the template that drop the substitution."""
+    assert "__SVG_NATIVE_PATH_BUDGET__" not in WALKER_JS
+    assert f"<= {SVG_NATIVE_PATH_BUDGET}" in WALKER_JS
+
+
+def test_threshold_bumped_above_legacy_30():
+    """Lock in the bump from 30 → ≥200 so a future cleanup doesn't silently
+    revert it. Real charts ship 50-150 primitives; the old cap rasterized
+    every one of them."""
+    assert SVG_NATIVE_PATH_BUDGET >= 200


### PR DESCRIPTION
Previously, A/a commands in SVG path data degraded to a straight line to
the arc endpoint, silently dropping curvature on rounded icons, chart
axis ticks, donut charts, etc. Now we convert each arc to up to four
cubic Bezier segments (one per ≤π/2 sweep) using the standard endpoint→
center parameterization (W3C SVG F.6.5/F.6.6) and the Maisonobe cubic
approximation. Spec-conformant edge cases (rx=0/ry=0 → line; equal
endpoints → omit) are handled.

Tests cover quarter-circle, full-circle (4-segment split), large-arc and
sweep flag selection of opposite centers, relative arc, degenerate radii,
coincident endpoints, and that the emitted XML uses cubicBezTo (not the
old lnTo fallback).