### PR TITLE
clip-path: native preset shapes for inset(), circle(), polygon()

### DIFF
--- a/slidify/classifier/tier1.py
+++ b/slidify/classifier/tier1.py
@@ -12,6 +12,7 @@ from slidify.dom_walker import SVG_NATIVE_PATH_BUDGET
 from slidify.geom import parse_px
 from slidify.gradients import parse_gradient
 from slidify.models import Decision, DecisionKind, UnitKind, VisualUnit
+from slidify.preset_shapes import clip_path_to_preset
 from slidify.shadows import is_translatable_shadow
 from slidify.svg_shapes import is_translatable_svg
 
@@ -106,6 +107,22 @@ def _has_filter(unit: VisualUnit) -> bool:
 
 def _has_clip_path(unit: VisualUnit) -> bool:
     return any(e.clip_path and e.clip_path != "none" for e in unit.all_elements())
+
+
+def _has_untranslatable_clip_path(unit: VisualUnit) -> bool:
+    """True iff any element has a clip-path that doesn't map to a PPTX preset.
+
+    inset(), circle(), and a handful of polygon() shapes are emit-time
+    translatable via `slidify.preset_shapes`; any other expression
+    (path(), url(#mask), unrecognized polygon) still forces raster.
+    """
+    for e in unit.all_elements():
+        cp = e.clip_path
+        if not cp or cp == "none":
+            continue
+        if clip_path_to_preset(cp, e.bbox) is None:
+            return True
+    return False
 
 
 def _has_mix_blend_mode(unit: VisualUnit) -> bool:
@@ -400,14 +417,20 @@ def rule_filter_raster(unit: VisualUnit) -> Decision | None:
 
 
 def rule_clip_path_raster(unit: VisualUnit) -> Decision | None:
-    if _has_clip_path(unit):
-        return Decision(
-            kind=DecisionKind.Raster,
-            confidence=0.9,
-            reason="clip_path",
-            source_tier="tier1",
-        )
-    return None
+    if not _has_clip_path(unit):
+        return None
+    if not _has_untranslatable_clip_path(unit):
+        # All clip-paths in this unit map to PPTX preset shapes — defer to
+        # the native rules (plain_rectangle / leaf_text / etc.) so the
+        # emitter can render `inset()` / `circle()` / common `polygon()`
+        # via MSO_SHAPE primitives instead of rasterizing the unit.
+        return None
+    return Decision(
+        kind=DecisionKind.Raster,
+        confidence=0.9,
+        reason="clip_path",
+        source_tier="tier1",
+    )
 
 
 def rule_pptx_unsupported_raster(unit: VisualUnit) -> Decision | None:

--- a/slidify/emitter.py
+++ b/slidify/emitter.py
@@ -834,9 +834,10 @@ class Emitter:
                 return False
         # Decorative overlays may sit off-canvas (top:-220px etc); preserve
         # the original origin so the gradient center isn't displaced.
-        x, y, w, h = _emu_rect_offcanvas(op.bbox)
         radius = parse_px(anchor.border_radius)
-        shape_kind = _shape_kind_for_anchor(anchor, radius)
+        shape_kind, bbox_override = _shape_kind_for_anchor(anchor, radius)
+        shape_bbox = bbox_override if bbox_override is not None else op.bbox
+        x, y, w, h = _emu_rect_offcanvas(shape_bbox)
         deco_stack = derive_decorations(anchor, palette=self._brand_palette)
         if not deco_stack.is_empty():
             deco_stack.emit_below(slide, op.bbox)
@@ -854,9 +855,10 @@ class Emitter:
         if anchor_el is None:
             return
         # Decorative overlays may sit off-canvas — see _emit_native_decoration.
-        x, y, w, h = _emu_rect_offcanvas(op.bbox)
         radius = parse_px(anchor_el.border_radius)
-        shape_kind = _shape_kind_for_anchor(anchor_el, radius)
+        shape_kind, bbox_override = _shape_kind_for_anchor(anchor_el, radius)
+        shape_bbox = bbox_override if bbox_override is not None else op.bbox
+        x, y, w, h = _emu_rect_offcanvas(shape_bbox)
         deco_stack = derive_decorations(anchor_el, palette=self._brand_palette)
         if not deco_stack.is_empty():
             deco_stack.emit_below(slide, op.bbox)
@@ -1155,23 +1157,34 @@ class Emitter:
             log.warning("emitter.notes_failed", error=str(e))
 
 
-def _shape_kind_for_anchor(anchor: DomElement, radius_px: float):
+def _shape_kind_for_anchor(
+    anchor: DomElement, radius_px: float
+) -> tuple[int, BoundingBox | None]:
     """Pick the right MSO_SHAPE for an anchor.
 
     Priority: explicit clip-path / class hint → preset (chevron, arrow,
     star, hexagon, callout, etc.) via `slidify.preset_shapes`. Then fall
     back to OVAL for true circles, ROUNDED_RECTANGLE for radius > 0,
     RECTANGLE otherwise.
+
+    Returns `(preset, bbox_override)`. `bbox_override` is non-None when
+    the matched preset implies a smaller visible area than the source
+    element (e.g. `clip-path: inset(...)` shrinks the rectangle, and
+    `clip-path: circle(...)` clips to an inscribed disc) — callers must
+    place the shape at the override bbox rather than the unit bbox.
     """
     match = detect_preset_shape(anchor)
     if match is not None:
-        return match.preset
+        return match.preset, match.bbox_override
     w = anchor.bbox.w
     h = anchor.bbox.h
     if w > 0 and h > 0:
         if radius_px >= min(w, h) * 0.45:
-            return MSO_SHAPE.OVAL
-    return MSO_SHAPE.ROUNDED_RECTANGLE if radius_px > 0 else MSO_SHAPE.RECTANGLE
+            return MSO_SHAPE.OVAL, None
+    return (
+        MSO_SHAPE.ROUNDED_RECTANGLE if radius_px > 0 else MSO_SHAPE.RECTANGLE,
+        None,
+    )
 
 
 def _union_line_box(unit: VisualUnit) -> BoundingBox | None:

--- a/slidify/preset_shapes.py
+++ b/slidify/preset_shapes.py
@@ -11,12 +11,15 @@ from pptx.enum.shapes import MSO_SHAPE
 from slidify.models import BoundingBox, DomElement
 
 __all__ = [
+    "KNOWN_PRESETS",
     "PresetMatch",
+    "classify_polygon",
+    "clip_path_to_preset",
     "detect_preset_shape",
     "emit_preset",
-    "KNOWN_PRESETS",
+    "parse_circle_clip_path",
+    "parse_inset_clip_path",
     "parse_polygon_clip_path",
-    "classify_polygon",
 ]
 
 
@@ -26,6 +29,10 @@ class PresetMatch:
     rotation_deg: float = 0.0
     confidence: float = 1.0
     reason: str = ""
+    # When set, the emitter should place the shape at this absolute bbox
+    # instead of the source element's bbox — used by `clip-path: inset(...)`
+    # and `clip-path: circle(...)` which shrink the visible area.
+    bbox_override: BoundingBox | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +337,205 @@ def classify_polygon(pts: list[tuple[float, float]]) -> PresetMatch | None:
 
 
 # ---------------------------------------------------------------------------
+# clip-path: inset(...) and circle(...) parsing
+# ---------------------------------------------------------------------------
+
+_INSET_RE = re.compile(r"^\s*inset\s*\(\s*(.*?)\s*\)\s*$", re.IGNORECASE | re.DOTALL)
+_CIRCLE_RE = re.compile(r"^\s*circle\s*\(\s*(.*?)\s*\)\s*$", re.IGNORECASE | re.DOTALL)
+
+
+def _parse_length(s: str, ref: float) -> float | None:
+    """Parse a CSS length ('10%', '20px', '0') to absolute pixels.
+
+    `ref` is the reference dimension used to resolve percentages.
+    """
+    s = s.strip().lower()
+    if not s:
+        return None
+    if s.endswith("%"):
+        try:
+            return float(s[:-1]) / 100.0 * ref
+        except ValueError:
+            return None
+    if s.endswith("px"):
+        try:
+            return float(s[:-2])
+        except ValueError:
+            return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def parse_inset_clip_path(
+    value: str, bbox: BoundingBox
+) -> tuple[BoundingBox, float] | None:
+    """Parse `inset(top right? bottom? left? round radius?)`.
+
+    Returns `(visible_bbox, corner_radius_px)` in absolute coordinates,
+    or None if the expression is not a valid inset().
+    """
+    if not value:
+        return None
+    m = _INSET_RE.match(value)
+    if not m:
+        return None
+    args = m.group(1).strip()
+    if not args:
+        return None
+
+    radius_px = 0.0
+    lower = args.lower()
+    if " round " in lower:
+        idx = lower.index(" round ")
+        radius_part = args[idx + len(" round ") :].strip()
+        args = args[:idx].strip()
+        first = radius_part.split()[0] if radius_part.split() else ""
+        rp = _parse_length(first, min(bbox.w, bbox.h))
+        if rp is not None:
+            radius_px = rp
+
+    parts = args.split()
+    if len(parts) == 1:
+        t = rt = bt = lt = parts[0]
+    elif len(parts) == 2:
+        t, rt = parts
+        bt, lt = t, rt
+    elif len(parts) == 3:
+        t, rt, bt = parts
+        lt = rt
+    elif len(parts) == 4:
+        t, rt, bt, lt = parts
+    else:
+        return None
+
+    top = _parse_length(t, bbox.h)
+    right = _parse_length(rt, bbox.w)
+    bottom = _parse_length(bt, bbox.h)
+    left = _parse_length(lt, bbox.w)
+    if top is None or right is None or bottom is None or left is None:
+        return None
+
+    new_w = max(0.0, bbox.w - left - right)
+    new_h = max(0.0, bbox.h - top - bottom)
+    if new_w <= 0 or new_h <= 0:
+        return None
+    return (
+        BoundingBox(x=bbox.x + left, y=bbox.y + top, w=new_w, h=new_h),
+        radius_px,
+    )
+
+
+def parse_circle_clip_path(value: str, bbox: BoundingBox) -> BoundingBox | None:
+    """Parse `circle(radius? at cx? cy?)` to the absolute bbox of the visible
+    inscribed circle. Returns None if the expression is not a valid circle().
+    """
+    if not value:
+        return None
+    m = _CIRCLE_RE.match(value)
+    if not m:
+        return None
+    inner = m.group(1).strip()
+
+    radius_arg = ""
+    cx_arg: str | None = None
+    cy_arg: str | None = None
+    lower = inner.lower()
+    if " at " in lower:
+        idx = lower.index(" at ")
+        radius_arg = inner[:idx].strip()
+        position = inner[idx + len(" at ") :].strip().split()
+        if len(position) >= 2:
+            cx_arg, cy_arg = position[0], position[1]
+        elif len(position) == 1:
+            cx_arg = cy_arg = position[0]
+    else:
+        radius_arg = inner.strip()
+
+    cx = _parse_length(cx_arg, bbox.w) if cx_arg else bbox.w / 2.0
+    cy = _parse_length(cy_arg, bbox.h) if cy_arg else bbox.h / 2.0
+    if cx is None or cy is None:
+        return None
+
+    radius_arg_l = radius_arg.lower()
+    if radius_arg_l in ("", "closest-side"):
+        radius = min(cx, bbox.w - cx, cy, bbox.h - cy)
+    elif radius_arg_l == "farthest-side":
+        radius = max(cx, bbox.w - cx, cy, bbox.h - cy)
+    else:
+        # Per CSS spec, % radius resolves against
+        # sqrt(w^2 + h^2) / sqrt(2). For square boxes this equals the side
+        # length, so circle(50%) of a 100x100 box is a radius-50 circle —
+        # i.e., the inscribed circle, which is the common author intent.
+        if radius_arg.endswith("%"):
+            try:
+                pct = float(radius_arg[:-1]) / 100.0
+            except ValueError:
+                return None
+            radius = pct * math.sqrt(bbox.w * bbox.w + bbox.h * bbox.h) / math.sqrt(2)
+        else:
+            r = _parse_length(radius_arg, min(bbox.w, bbox.h))
+            if r is None:
+                return None
+            radius = r
+
+    if radius <= 0:
+        return None
+    return BoundingBox(
+        x=bbox.x + cx - radius,
+        y=bbox.y + cy - radius,
+        w=2 * radius,
+        h=2 * radius,
+    )
+
+
+def clip_path_to_preset(value: str, bbox: BoundingBox) -> PresetMatch | None:
+    """Map any `clip-path` value to a PresetMatch, or None if untranslatable.
+
+    Handles:
+      - `polygon(...)` via the existing classifier
+      - `inset(...)` -> RECTANGLE / ROUNDED_RECTANGLE (with bbox shrink)
+      - `circle(...)` -> OVAL (with bbox shrink to inscribed square)
+    """
+    if not value or value.strip().lower() == "none":
+        return None
+    v = value.strip()
+
+    inset = parse_inset_clip_path(v, bbox)
+    if inset is not None:
+        new_bbox, radius_px = inset
+        if radius_px > 0:
+            return PresetMatch(
+                preset=MSO_SHAPE.ROUNDED_RECTANGLE,
+                confidence=0.9,
+                reason="clip_path inset round",
+                bbox_override=new_bbox,
+            )
+        return PresetMatch(
+            preset=MSO_SHAPE.RECTANGLE,
+            confidence=0.95,
+            reason="clip_path inset",
+            bbox_override=new_bbox,
+        )
+
+    circle = parse_circle_clip_path(v, bbox)
+    if circle is not None:
+        return PresetMatch(
+            preset=MSO_SHAPE.OVAL,
+            confidence=0.95,
+            reason="clip_path circle",
+            bbox_override=circle,
+        )
+
+    pts = parse_polygon_clip_path(v)
+    if pts is not None:
+        return classify_polygon(pts)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
 # border-radius helpers
 # ---------------------------------------------------------------------------
 
@@ -408,14 +614,12 @@ def _resolve_border_radius(el: DomElement) -> str:
 def detect_preset_shape(el: DomElement) -> PresetMatch | None:
     """Detect a non-rectangular MSO preset for this element, or None."""
 
-    # 1. clip-path: polygon(...)
+    # 1. clip-path: polygon(...) / inset(...) / circle(...)
     clip = _resolve_clip_path(el)
     if clip:
-        pts = parse_polygon_clip_path(clip)
-        if pts is not None:
-            match = classify_polygon(pts)
-            if match is not None:
-                return match
+        match = clip_path_to_preset(clip, el.bbox)
+        if match is not None:
+            return match
 
     # 2. CSS class hints
     if el.cls:

--- a/slidify/promotion.py
+++ b/slidify/promotion.py
@@ -95,7 +95,10 @@ def _native_decoration_only(unit: VisualUnit) -> bool:
     if a.filter and a.filter != "none":
         return False
     if a.clip_path and a.clip_path != "none":
-        return False
+        from slidify.preset_shapes import clip_path_to_preset
+
+        if clip_path_to_preset(a.clip_path, a.bbox) is None:
+            return False
     if a.background_image and a.background_image != "none":
         if "url(" in a.background_image:
             return False

--- a/tests/unit/test_preset_shapes.py
+++ b/tests/unit/test_preset_shapes.py
@@ -14,8 +14,11 @@ from slidify.preset_shapes import (
     KNOWN_PRESETS,
     PresetMatch,
     classify_polygon,
+    clip_path_to_preset,
     detect_preset_shape,
     emit_preset,
+    parse_circle_clip_path,
+    parse_inset_clip_path,
     parse_polygon_clip_path,
 )
 
@@ -188,3 +191,143 @@ def test_emit_preset_with_rotation():
     match = PresetMatch(preset=MSO_SHAPE.STAR_5_POINT, rotation_deg=45.0)
     shape = emit_preset(slide, bbox, match)
     assert abs(shape.rotation - 45.0) < 0.01
+
+
+# clip-path: inset(...) ------------------------------------------------------
+
+
+def test_inset_uniform_percent_to_rectangle():
+    bbox = BoundingBox(x=0, y=0, w=200, h=100)
+    inset = parse_inset_clip_path("inset(10%)", bbox)
+    assert inset is not None
+    new_bbox, radius = inset
+    assert radius == 0.0
+    assert new_bbox.x == 20.0  # 10% of 200
+    assert new_bbox.y == 10.0  # 10% of 100
+    assert new_bbox.w == 160.0
+    assert new_bbox.h == 80.0
+
+
+def test_inset_two_value_percent():
+    bbox = BoundingBox(x=0, y=0, w=200, h=100)
+    inset = parse_inset_clip_path("inset(10% 20%)", bbox)
+    assert inset is not None
+    new_bbox, _ = inset
+    # top/bottom = 10% of 100, left/right = 20% of 200
+    assert new_bbox.x == 40.0
+    assert new_bbox.y == 10.0
+    assert new_bbox.w == 120.0  # 200 - 40 - 40
+    assert new_bbox.h == 80.0
+
+
+def test_inset_four_value_pixel():
+    bbox = BoundingBox(x=100, y=200, w=300, h=200)
+    inset = parse_inset_clip_path("inset(5px 10px 15px 20px)", bbox)
+    assert inset is not None
+    new_bbox, _ = inset
+    assert new_bbox.x == 120.0  # 100 + 20px left
+    assert new_bbox.y == 205.0  # 200 + 5px top
+    assert new_bbox.w == 270.0  # 300 - 10 right - 20 left
+    assert new_bbox.h == 180.0  # 200 - 5 top - 15 bottom
+
+
+def test_inset_round_yields_rounded_rectangle():
+    el = _el(
+        clip_path="inset(10% round 8px)",
+        bbox=BoundingBox(x=0, y=0, w=200, h=100),
+    )
+    match = detect_preset_shape(el)
+    assert match is not None
+    assert match.preset == MSO_SHAPE.ROUNDED_RECTANGLE
+    assert match.bbox_override is not None
+    assert match.bbox_override.w == 160.0
+
+
+def test_inset_no_round_yields_rectangle():
+    el = _el(
+        clip_path="inset(20px)",
+        bbox=BoundingBox(x=0, y=0, w=200, h=100),
+    )
+    match = detect_preset_shape(el)
+    assert match is not None
+    assert match.preset == MSO_SHAPE.RECTANGLE
+    assert match.bbox_override is not None
+    assert match.bbox_override.w == 160.0
+    assert match.bbox_override.h == 60.0
+
+
+def test_inset_invalid_returns_none():
+    bbox = BoundingBox(x=0, y=0, w=200, h=100)
+    assert parse_inset_clip_path("none", bbox) is None
+    assert parse_inset_clip_path("inset()", bbox) is None
+    assert parse_inset_clip_path("circle(50%)", bbox) is None
+
+
+# clip-path: circle(...) -----------------------------------------------------
+
+
+def test_circle_default_inscribes_in_square():
+    bbox = BoundingBox(x=0, y=0, w=100, h=100)
+    visible = parse_circle_clip_path("circle()", bbox)
+    assert visible is not None
+    assert visible.x == 0.0
+    assert visible.y == 0.0
+    assert visible.w == 100.0
+    assert visible.h == 100.0
+
+
+def test_circle_default_inscribes_in_rect():
+    bbox = BoundingBox(x=0, y=0, w=200, h=100)
+    visible = parse_circle_clip_path("circle()", bbox)
+    assert visible is not None
+    # closest-side from center (100, 50) → min(100, 100, 50, 50) = 50
+    assert visible.w == 100.0
+    assert visible.h == 100.0
+    assert visible.x == 50.0  # centered
+    assert visible.y == 0.0
+
+
+def test_circle_pixel_radius_at_center():
+    bbox = BoundingBox(x=10, y=20, w=200, h=100)
+    visible = parse_circle_clip_path("circle(30px at 50% 50%)", bbox)
+    assert visible is not None
+    assert visible.w == 60.0
+    assert visible.h == 60.0
+    assert visible.x == 80.0  # 10 + 100 - 30
+    assert visible.y == 40.0  # 20 + 50 - 30
+
+
+def test_circle_yields_oval_preset():
+    el = _el(
+        clip_path="circle(50%)",
+        bbox=BoundingBox(x=0, y=0, w=80, h=80),
+    )
+    match = detect_preset_shape(el)
+    assert match is not None
+    assert match.preset == MSO_SHAPE.OVAL
+    assert match.bbox_override is not None
+    # circle(50%) on a square: radius = 50% * sqrt(2*w^2)/sqrt(2) = w/2
+    assert abs(match.bbox_override.w - 80.0) < 1e-6
+
+
+# clip_path_to_preset entry point -------------------------------------------
+
+
+def test_clip_path_to_preset_polygon_dispatches():
+    bbox = BoundingBox(x=0, y=0, w=100, h=100)
+    pts = []
+    for i in range(6):
+        ang = 2 * math.pi * i / 6
+        pts.append((0.5 + 0.5 * math.cos(ang), 0.5 + 0.5 * math.sin(ang)))
+    poly = "polygon(" + ", ".join(f"{p[0] * 100}% {p[1] * 100}%" for p in pts) + ")"
+    match = clip_path_to_preset(poly, bbox)
+    assert match is not None
+    assert match.preset == MSO_SHAPE.HEXAGON
+
+
+def test_clip_path_to_preset_unknown_returns_none():
+    bbox = BoundingBox(x=0, y=0, w=100, h=100)
+    assert clip_path_to_preset("path('M 0 0 L 1 1')", bbox) is None
+    assert clip_path_to_preset("url(#mask)", bbox) is None
+    assert clip_path_to_preset("none", bbox) is None
+    assert clip_path_to_preset("", bbox) is None

--- a/tests/unit/test_tier1_clip_path.py
+++ b/tests/unit/test_tier1_clip_path.py
@@ -1,0 +1,67 @@
+"""Tier-1 routing for `clip-path` — translatable expressions defer to
+native rules; everything else still rasterizes."""
+
+from __future__ import annotations
+
+from slidify.classifier.tier1 import (
+    _has_untranslatable_clip_path,
+    rule_clip_path_raster,
+)
+from slidify.models import BoundingBox, DecisionKind, DomElement, UnitKind, VisualUnit
+
+
+def _unit(clip_path: str, w: int = 200, h: int = 200) -> VisualUnit:
+    bbox = BoundingBox(x=0, y=0, w=w, h=h)
+    el = DomElement(
+        id=1,
+        parent_id=None,
+        depth=0,
+        tag="div",
+        bbox=bbox,
+        clip_path=clip_path,
+    )
+    return VisualUnit(id="u", kind=UnitKind.Generic, bbox=bbox, elements=[el])
+
+
+def test_inset_clip_path_defers_to_native():
+    decision = rule_clip_path_raster(_unit("inset(10%)"))
+    assert decision is None
+
+
+def test_circle_clip_path_defers_to_native():
+    decision = rule_clip_path_raster(_unit("circle(50%)"))
+    assert decision is None
+
+
+def test_polygon_hexagon_clip_path_defers_to_native():
+    # Regular hexagon — preset_shapes.classify_polygon recognises it.
+    poly = (
+        "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)"
+    )
+    decision = rule_clip_path_raster(_unit(poly))
+    assert decision is None
+
+
+def test_unknown_clip_path_still_rasterizes():
+    decision = rule_clip_path_raster(_unit("path('M 0 0 L 1 1 Z')"))
+    assert decision is not None
+    assert decision.kind == DecisionKind.Raster
+    assert decision.reason == "clip_path"
+
+
+def test_url_mask_still_rasterizes():
+    decision = rule_clip_path_raster(_unit("url(#mask)"))
+    assert decision is not None
+    assert decision.kind == DecisionKind.Raster
+
+
+def test_no_clip_path_returns_none():
+    decision = rule_clip_path_raster(_unit("none"))
+    assert decision is None
+
+
+def test_has_untranslatable_clip_path_helper():
+    assert _has_untranslatable_clip_path(_unit("inset(5px)")) is False
+    assert _has_untranslatable_clip_path(_unit("circle()")) is False
+    assert _has_untranslatable_clip_path(_unit("path('M 0 0')")) is True
+    assert _has_untranslatable_clip_path(_unit("none")) is False


### PR DESCRIPTION
inset() and circle() join polygon() on the native emit path. tier1's
clip-path rule now defers when the expression maps to a PPTX preset
(MSO_SHAPE.RECTANGLE/ROUNDED_RECTANGLE/OVAL), and the emitter shrinks
the shape's bbox to the visible area instead of rasterizing the unit.
Avoids forced raster on avatar/badge/pill clip-paths that browsers
write as inset/circle.