### PR TITLE
Add text-wrap stress corpus slide and Skia text-measurement backend selection

### DIFF
--- a/_bench/corpus/slide-67-text-wrap-stress.html
+++ b/_bench/corpus/slide-67-text-wrap-stress.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Wrap Stress</title>
+  <style>
+    :root { color-scheme: light; }
+    html, body {
+      margin: 0;
+      width: 1366px;
+      height: 768px;
+      font-family: "Inter", "Segoe UI", Arial, sans-serif;
+      background: linear-gradient(135deg, #0b1020 0%, #1a2451 45%, #1a4d82 100%);
+      color: #eef3ff;
+    }
+    .slide {
+      box-sizing: border-box;
+      width: 100%;
+      height: 100%;
+      padding: 56px 68px;
+      display: grid;
+      grid-template-rows: auto auto 1fr;
+      gap: 28px;
+    }
+    h1 { margin: 0; font-size: 56px; line-height: 1.08; letter-spacing: -0.02em; max-width: 1080px; }
+    .subtitle { font-size: 24px; line-height: 1.35; opacity: .92; max-width: 1140px; }
+    .cards { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 22px; }
+    .card {
+      background: rgba(255,255,255,.08);
+      border: 1px solid rgba(255,255,255,.18);
+      border-radius: 18px;
+      padding: 20px 22px;
+      box-shadow: 0 12px 28px rgba(4,9,22,.28);
+    }
+    .k { font-size: 14px; text-transform: uppercase; letter-spacing: .08em; opacity: .72; margin-bottom: 10px; }
+    .v { font-size: 30px; line-height: 1.18; font-weight: 650; }
+  </style>
+</head>
+<body>
+  <section class="slide">
+    <h1>Operationally, this quarter validated a deliberate “native-first, raster-fallback” strategy for complex slides.</h1>
+    <div class="subtitle">We improved deterministic wrapping across long phrases, numerals (123,456,789), symbols (&amp; + / %), and punctuation-heavy snippets—without sacrificing editability in PowerPoint.</div>
+    <div class="cards">
+      <article class="card"><div class="k">Fidelity</div><div class="v">93.4% average SSIM across stress scenarios with multi-line title/lede structures.</div></article>
+      <article class="card"><div class="k">Editability</div><div class="v">88% of visible area emitted as native text/shape/table primitives.</div></article>
+      <article class="card"><div class="k">Latency</div><div class="v">1.7s median single-slide conversion at standard preview resolution.</div></article>
+    </div>
+  </section>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "google-cloud-aiplatform>=1.60",
     "pyyaml>=6.0.3",
     "fonttools>=4.50",
+    "skia-python>=138.0",
 ]
 
 [project.scripts]

--- a/slidify/text_metrics.py
+++ b/slidify/text_metrics.py
@@ -33,6 +33,8 @@ __all__ = [
 
 # 1pt = 1/72in, 1px = 1/96in, so 1pt = 96/72 = 1.333... px
 _PX_PER_PT = 96.0 / 72.0
+_SKIA_BACKEND = "skia"
+_FONTTOOLS_BACKEND = "fonttools"
 
 
 @dataclass
@@ -116,6 +118,10 @@ def measure_text(
 ) -> TextMetrics:
     """Measure a text string in the given font at the given pt size."""
     fp = str(Path(font_path))
+    if _text_metrics_backend() == _SKIA_BACKEND:
+        skia_metrics = _measure_text_skia(text, fp, size_pt)
+        if skia_metrics is not None:
+            return skia_metrics
     upem = _font_unitsperem(fp)
     px_per_unit = (size_pt / upem) * _PX_PER_PT
     width = _advance_units(fp, text) * px_per_unit
@@ -133,8 +139,43 @@ def measure_text_width_px(
 ) -> float:
     """Convenience — just the advance width in px (1pt = 1.333px)."""
     fp = str(Path(font_path))
+    if _text_metrics_backend() == _SKIA_BACKEND:
+        skia_metrics = _measure_text_skia(text, fp, size_pt)
+        if skia_metrics is not None:
+            return skia_metrics.width_px
     upem = _font_unitsperem(fp)
     return _advance_units(fp, text) * (size_pt / upem) * _PX_PER_PT
+
+
+def _text_metrics_backend() -> str:
+    backend = os.getenv("SLIDIFY_TEXT_METRICS_BACKEND", _FONTTOOLS_BACKEND).strip().lower()
+    if backend in {_FONTTOOLS_BACKEND, _SKIA_BACKEND}:
+        return backend
+    return _FONTTOOLS_BACKEND
+
+
+def _measure_text_skia(text: str, font_path: str, size_pt: float) -> TextMetrics | None:
+    try:
+        import skia  # type: ignore
+    except Exception:
+        return None
+    if not Path(font_path).is_file():
+        return None
+
+    font_mgr = skia.FontMgr()
+    typeface = font_mgr.makeFromFile(font_path)
+    if typeface is None:
+        return None
+    font_size_px = size_pt * _PX_PER_PT
+    font = skia.Font(typeface, font_size_px)
+    width = float(font.measureText(text or ""))
+    metrics = font.getMetrics()
+    return TextMetrics(
+        width_px=width,
+        ascent_px=float(abs(metrics.fAscent)),
+        descent_px=float(metrics.fDescent),
+        line_gap_px=float(metrics.fLeading),
+    )
 
 
 # ----- font discovery -----------------------------------------------------

--- a/tests/unit/test_text_metrics.py
+++ b/tests/unit/test_text_metrics.py
@@ -10,6 +10,7 @@ import pytest
 
 from slidify.models import BoundingBox
 from slidify.text_metrics import (
+    _text_metrics_backend,
     compute_font_scale_for_textbox,
     get_fallback_font_path,
     get_inter_font_path,
@@ -166,3 +167,13 @@ def test_empty_text_zero_width():
     m = measure_text("", inter, 18.0)
     assert m.width_px == 0
     assert measure_text_width_px("", inter, 18.0) == 0
+
+
+def test_text_metrics_backend_defaults_to_fonttools(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("SLIDIFY_TEXT_METRICS_BACKEND", raising=False)
+    assert _text_metrics_backend() == "fonttools"
+
+
+def test_text_metrics_backend_invalid_value_falls_back(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SLIDIFY_TEXT_METRICS_BACKEND", "not-real")
+    assert _text_metrics_backend() == "fonttools"


### PR DESCRIPTION
### Motivation
- Improve coverage for text-measurement and line-break fidelity by adding a focused corpus slide that stresses multi-line titles, punctuation/numeric wrapping, and dense card copy. 
- Provide a renderer-consistent optional text measurement path so complex wrapping/line-break decisions can be made from a deterministic engine when available. 
- Make backend selection explicit and testable so environments without Skia continue to use the existing `fontTools` logic without regressions. 

### Description
- Add a new benchmark fixture `_bench/corpus/slide-67-text-wrap-stress.html` that contains a 1366×768 slide exercising long hero text, a punctuation-heavy subtitle, and three KPI cards. 
- Extend `slidify/text_metrics.py` with backend identifiers and selection logic via `_text_metrics_backend()` (driven by `SLIDIFY_TEXT_METRICS_BACKEND`), and wire `measure_text` and `measure_text_width_px` to prefer the Skia path when selected. 
- Add `_measure_text_skia()` which uses `skia` (if available) to measure glyph advances and metrics and falls back to existing `fontTools`-based computations when Skia or the font file is unavailable. 
- Add unit tests in `tests/unit/test_text_metrics.py` to verify backend selection behavior (default and invalid-value fallback). 

### Testing
- Ran the text-metrics unit module with `uv run pytest tests/unit/test_text_metrics.py -q`, which completed successfully (`5 passed, 9 skipped`). 
- Executed the conversion pipeline for the new corpus slide with `uv run slidify _bench/corpus/slide-67-text-wrap-stress.html _bench/corpus/out/slide-67-text-wrap-stress.pptx`, which produced a PPTX artifact. 
- Rendered the produced PPTX to PNG using LibreOffice and `pdftoppm` in an automated render step and confirmed the preview PNG was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4931d22908321820a56afa911c105)