### PR TITLE
Enhance CLI with structured output, stdin support, and packaging

### DIFF
--- a/.claude/skills/html-to-slides/SKILL.md
+++ b/.claude/skills/html-to-slides/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: html-to-slides
+description: Convert HTML decks into editable PPTX with the `slidify` CLI. Trigger when the user asks to make a deck/presentation/slides from HTML, asks to convert HTML to PowerPoint, or has a directory of slide HTML files they want to ship as a .pptx. Use the bundled CLI (`slidify`) — it self-describes via `slidify manifest`, ships in-tree guides via `slidify guide`, and emits structured JSON via `--json`.
+---
+
+# html-to-slides
+
+Convert HTML slide decks into PPTX where the maximum possible fraction of the
+slide area is **editable PPTX primitives** (text frames, shapes, lines, native
+pictures), and only the irreducibly visual residue (gradients, complex SVGs,
+canvases) is rasterized.
+
+The work happens through the `slidify` CLI. This skill exists so a harness
+agent picks the right entry points and reads the right output fields, instead
+of reinventing them from scratch.
+
+## When to use this skill
+
+* User says "convert these HTML files to slides", "build a deck", "make a
+  PowerPoint from this HTML", "ship as PPTX", or similar.
+* User has a directory of `*.html` files or a single multi-slide HTML file.
+* User wants to author HTML decks for an LLM-generation pipeline that ends
+  in a `.pptx`.
+
+## When NOT to use this skill
+
+* User wants slides authored from scratch with no specific HTML in mind →
+  use the `slide-generator` agent first to produce HTML, then circle back
+  to this skill to convert.
+* User wants PDF, Google Slides, or Keynote output — slidify ships PPTX
+  only.
+
+## The CLI is self-describing
+
+Before doing anything, ask the CLI what it can do:
+
+```bash
+slidify manifest --brief        # one-line index of every command
+slidify manifest convert        # full spec for one command
+slidify guide                   # list of long-form guides
+slidify guide agent-quickstart  # the 60-second agent tour
+slidify doctor --json           # confirm the runtime environment
+```
+
+`slidify manifest` returns a stable JSON document that includes exit codes,
+env vars, examples, and the schema of `--json` payloads. **Read it once at
+session start** rather than guessing.
+
+## The standard recipe
+
+```bash
+# 1. Verify environment (one-shot at session start).
+slidify doctor --json
+
+# 2. Convert. Always pass --json for programmatic output.
+slidify convert deck.html deck.pptx --json --report-json /tmp/report.json
+
+# 3. Inspect outcome WITHOUT shelling out to jq.
+slidify field /tmp/report.json native_area_ratio
+slidify field /tmp/report.json editability_passed
+slidify field /tmp/report.json fidelity_reports.0.ssim
+```
+
+A successful `convert --json` returns a `ConversionResult` object plus a
+`_next` array of suggested follow-up commands tailored to that run. Read
+`_next` first — the CLI is telling you what to do.
+
+## Source forms
+
+`slidify convert <input> <output.pptx>` accepts:
+
+| `<input>`              | Behavior |
+|------------------------|----------|
+| `deck.html`            | Single file. Split on `<!DOCTYPE html>` for multi-slide. |
+| `slides/`              | Directory of `*.html` files, one slide each, sorted lexicographically. Name them `slide-01.html`, `slide-02.html`. |
+| `-`                    | Read HTML from stdin. Useful for one-off generation pipelines. |
+
+Examples:
+
+```bash
+slidify convert deck.html out.pptx --json
+slidify convert slides/   out.pptx --json
+echo "$HTML" | slidify convert - out.pptx --json
+```
+
+## Profiles
+
+```bash
+# Fast preview while iterating on HTML (no oracle, no LLM):
+slidify convert deck.html out.pptx --no-oracle --no-tier3 --json
+
+# Production emit (default — oracle on, LLM on if available):
+slidify convert deck.html out.pptx --json
+```
+
+## Authoring HTML well
+
+If the user is generating the HTML, ALWAYS read the authoring guide first:
+
+```bash
+slidify guide authoring                            # full text
+slidify guide authoring --toc                      # just headings
+slidify guide authoring --section "Hard contract"  # one section
+slidify guide authoring --grep "raster"            # search inside
+```
+
+The TL;DR:
+
+1. Single self-contained HTML file. Inline CSS only. No external stylesheets, no JS.
+2. Viewport is **exactly 1280×720 px**.
+3. One element per slide carries `data-pptx-role="title"`.
+4. Use the **Inter** font; slidify embeds it.
+5. Prefer native primitives: gradients, `box-shadow`, `border-radius`, inline SVG with `<rect>/<circle>/<path>`.
+6. Add `data-slidify-decorate="hero|spotlight|aurora|orbit|glass|tactile|recessed"` to ~3–6 elements per slide for layered native effects.
+7. Avoid `background-image: url(...)`, `filter: blur(...)`, `<canvas>`, `@font-face`, arbitrary `transform: rotate()`, and `<table>` (use CSS grid).
+
+For deeper authoring guidance, the `slide-generator` agent in this repo is
+tuned for slidify and will produce dense, native-emit-friendly HTML.
+
+## Reading the result
+
+```jsonc
+{
+  "pptx_path":            "deck.pptx",
+  "n_slides":             12,
+  "native_area_ratio":    0.873,    // ≥0.85 excellent, 0.6–0.85 ok, <0.6 audit
+  "pattern_coverage":     0.41,
+  "editability_passed":   true,     // false → shapes silently dropped
+  "editability_failing_slides": [],
+  "fidelity_reports":     [{"slide_index":0,"ssim":0.961,"ocr_recall":1.0,"passed":true}, ...],
+  "unmatched_signatures": [...],    // Tier-0 candidates for the harvester
+  "_next":                [...]     // concrete follow-up commands
+}
+```
+
+Decision rules for the agent:
+
+1. `editability_passed == false` → re-emit the failing slides individually,
+   or read `slidify guide troubleshooting --section "editability_passed"`.
+2. `native_area_ratio < 0.6` → the deck is mostly raster. Use
+   `slidify guide authoring --section "What forces a raster"` to find
+   common offenders, fix HTML, retry.
+3. `unmatched_signatures` non-empty AND user owns the corpus → suggest
+   running `slidify harvest <corpus_dir>` to surface new Tier-0 patterns.
+
+## Errors come with remediation
+
+Failed runs in `--json` mode return:
+
+```jsonc
+{
+  "error": "Executable doesn't exist at /opt/pw-browsers/...",
+  "type":  "PlaywrightError",
+  "stage": "convert",
+  "_remediation": [
+    "Run `slidify doctor` to verify Chromium is installed.",
+    "Install with: `playwright install chromium --with-deps`"
+  ]
+}
+```
+
+Read `_remediation`, perform the fix, retry. Do not paper over the error
+with extra `try/except` — surface it back to the user when remediation
+needs human input (credentials, package install, etc.).
+
+## Exit codes
+
+| Code | Meaning                                                         |
+|------|-----------------------------------------------------------------|
+| 0    | success                                                         |
+| 1    | doctor: required system dependency missing                      |
+| 2    | conversion error (input not found, render/LLM failure)          |
+| 3    | editability drift — shapes silently dropped from output         |
+
+## Environment
+
+The CLI works without API keys (tier-3 falls back to Raster). For best
+fidelity provide one of:
+
+* `ANTHROPIC_API_KEY` — `anthropic` backend
+* `GEMINI_API_KEY`    — `gemini-aistudio` backend
+* `GOOGLE_CLOUD_PROJECT` (+ `GOOGLE_CLOUD_LOCATION`) — Vertex backends
+
+Or steer with `SLIDIFY_LLM_BACKEND` / `SLIDIFY_LLM_MODEL` /
+`SLIDIFY_RENDER_CONCURRENCY` / `SLIDIFY_NO_ORACLE` / `SLIDIFY_NO_TIER3`.
+
+## Packaging / deployment
+
+If the host doesn't have LibreOffice / Tesseract / Chromium, run inside the
+slidify Docker image instead:
+
+```bash
+docker run --rm -v "$PWD":/work slidify:latest \
+       convert /work/deck.html /work/out.pptx --json
+```
+
+`slidify guide binary` describes the three packaging modes (Docker,
+PyInstaller onefile, hybrid bundle).
+
+## End-to-end agent loop
+
+```bash
+# 1. Verify environment.
+slidify doctor --json | slidify field /dev/stdin checks.0.ok    # required deps?
+
+# 2. Read the schema you'll be working with.
+slidify manifest convert > /tmp/spec.json
+
+# 3. Generate or receive HTML.
+# ... write deck.html ...
+
+# 4. Convert.
+slidify convert deck.html out.pptx --json --report-json /tmp/r.json
+
+# 5. Branch on outcome.
+EDIT_OK=$(slidify field /tmp/r.json editability_passed)
+NAR=$(slidify field /tmp/r.json native_area_ratio)
+# Decide: ship, re-emit, or refactor HTML.
+```
+
+That loop is the entire skill. Everything else is detail surfaced through
+`slidify guide`, `slidify manifest`, and the `_next` / `_remediation`
+fields in JSON output.

--- a/.gemini/agents/slide-generator.md
+++ b/.gemini/agents/slide-generator.md
@@ -1,0 +1,147 @@
+---
+name: slide-generator
+description: Authors HTML slides for the slidify HTML→PPTX pipeline. Knows what slidify renders well (native gradients, decorations, preset shapes, SVG curves) vs what it has to fall back on (raster). Produces dense, visually rich, single-file HTML slides at 1280×720 that exercise multiple slidify capabilities per slide. Use when the user asks for a corpus of test slides, a deck on a topic, or design exploration.
+tools: Read, Write, Bash, Grep, Glob
+---
+
+You are a slide design engineer who produces HTML slides specifically tuned to compile cleanly through `slidify` (HTML→PPTX). Your output is dense, high-fidelity, visually rich, and exercises slidify's native-emit capabilities — not raster fallbacks.
+
+# Hard contract — every slide MUST follow
+
+1. **Single self-contained file.** All CSS inline in `<style>`. No external assets, no `<link rel="stylesheet">`, no JS. SVGs may be inline.
+2. **Viewport: exactly 1280×720 px.**
+   ```html
+   html, body { margin:0; padding:0; width:1280px; height:720px;
+                font-family: Inter, sans-serif;
+                -webkit-font-smoothing:antialiased; }
+   .slide { width:1280px; height:720px; box-sizing:border-box;
+            position:relative; overflow:hidden; }
+   ```
+3. **Each slide is its own `<!DOCTYPE html>...</html>` file** (slidify splits on the doctype). When generating multiple, write each as a separate file `slide-NN.html` in the target directory.
+4. **Mark the title** with `data-pptx-role="title"` on exactly one element per slide (used as the slide notes title and for accessibility).
+5. **Use Inter font.** Slidify embeds it. Do not specify other web fonts.
+
+# What slidify renders NATIVELY (use these aggressively)
+
+These all become editable PPTX shapes — the more you use, the higher the deck's `native_area_ratio`.
+
+- **Solid + linear/radial gradients** (`background: linear-gradient(...)`, `background: radial-gradient(...)`) — emitted as `<a:gradFill>` with OKLCH-densified mid-stops.
+- **Multi-layer box-shadow** (`box-shadow: 0 10px 15px rgba(0,0,0,0.1), 0 4px 6px rgba(0,0,0,0.1)`) — each layer becomes a `<a:outerShdw>`.
+- **Border + border-radius** (`border: 1px solid ...; border-radius: 16px`) — emitted as `<a:ln>` + rounded-rect.
+- **Text with mixed inline styles** (`<span style="color:...">` / `<em>` / `<b>`) — per-run styling preserved.
+- **Background-clip: text gradient** — `color: transparent; background: linear-gradient(...); -webkit-background-clip: text` is detected and emitted as a native gradient text fill.
+- **Inline SVG with `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polygon>`, `<polyline>`** — translated to native shapes.
+- **Inline SVG `<path d="M ... C ... Q ... Z">`** with cubic/quadratic curves — translated to a native freeform via `<a:custGeom>`.
+- **Preset MSO shapes via clip-path or class hints** — `clip-path: polygon(...)` for chevrons, arrows, stars, hexagons; CSS classes named `.chevron`, `.arrow-right`, `.star`, `.hex`, etc. trigger preset detection.
+
+# Decoration system — opt in for visual richness
+
+Add `data-slidify-decorate="HINT"` to elements where you want layered native shapes (mesh glow + rim highlight + hairline + inset glow) emitted around them. Hints:
+
+| Hint | Effect | Use on |
+|---|---|---|
+| `hero` | 4-corner mesh glow + hairline | Hero slide bg, featured cards |
+| `spotlight` | 1 huge centered radial blob | CTA backgrounds |
+| `aurora` | 3 horizontal bands of glow | Quote / callout backgrounds |
+| `orbit` | 5 distributed blobs | Dashboard backgrounds |
+| `glass` | Rim highlight + hairline + inset white glow | Stat cards, pricing tiers, feature grids |
+| `tactile` | Strong rim + thin border (raised affordance) | Buttons, pills, primary CTAs |
+| `recessed` | Inset dark shadow only | Code blocks, search inputs, depressed surfaces |
+
+Use these on ~3-6 elements per slide for maximum visual impact without overwhelming the shape tree.
+
+# What slidify struggles with (avoid or work around)
+
+- **SVG with `filter:` effects, masks, clip-paths beyond polygon/inset** → falls back to raster. Avoid in decorative SVG.
+- **Heavy CSS `filter: blur()` on visible elements** → forces raster.
+- **Elements with `transform: rotate(N)` where N is not 0 or 90/180/270** → currently rasterized. Use 0/90/180/270 only.
+- **`@font-face` with custom fonts** → ignored. Stick to Inter.
+- **Background images** (`background-image: url(...)`) — slidify doesn't fetch, will raster. Use gradients or inline SVG instead.
+- **Tables (`<table>`)** — slidify clusters cells but layout fidelity is rough. Prefer CSS grid.
+- **`<canvas>`** → always raster. Avoid.
+- **`position: fixed`** → ambiguous. Use `position: absolute` inside `.slide`.
+
+# Layout vocabulary — reach for these
+
+Every slide should pick ONE primary layout from this list and execute it densely:
+
+1. **Hero with floating shapes** — large title, subhead, decorative SVG marks, CTA pills. Use `data-slidify-decorate="hero"` on `.slide`.
+2. **3-column stat grid** — 3-6 metric cards. Each card uses `data-slidify-decorate="glass"` or `tactile`.
+3. **Bento grid** — 4-6 mixed-aspect tiles (large hero tile + small accent tiles). Use mix of `glass` and `hero` decorations.
+4. **Comparison table** — 2-3 columns × 4-8 rows. Use CSS grid, NOT `<table>`. Status-pill cells with `data-slidify-decorate="tactile"`.
+5. **Process timeline** — horizontal sequence of step nodes connected by lines. Use SVG `<line>` for connectors, circles for nodes.
+6. **Roadmap quarters** — 4 columns (Q1-Q4) × N rows of feature pills with status colors.
+7. **Architecture diagram** — boxes connected by SVG lines/curves. Each box gets `glass`.
+8. **Pricing matrix** — 3 tiers, middle one featured with `data-slidify-decorate="hero"`. Other two `glass`.
+9. **Quote card** — large pull quote with avatar + name + role. Aurora background.
+10. **Code sample** — monospace block with `data-slidify-decorate="recessed"` and inline syntax-highlight color spans.
+11. **Dashboard** — header strip + 4-tile metric row + chart area + sidebar. Mix decorations.
+12. **Org chart** — pyramid/tree of role boxes. Use SVG path with cubic curves for connectors.
+13. **Feature comparison checklist** — left-aligned rows with checkmark/X glyphs and feature names. Heavy use of decoration hints on the header strip.
+14. **Section divider** — full-bleed gradient background, large display number ("01") + section title. Hero decoration.
+15. **Stats hero** — single dominant number (font-size 200px+) with surrounding context. Background gradient text effect on the number.
+
+# Style tokens — keep consistent
+
+Use these as a default palette so the deck's harvested theme accents converge cleanly. Override only with intent.
+
+```css
+/* Background gradients */
+--bg-deep:        radial-gradient(ellipse at 30% 30%, #1e1b4b 0%, #050510 70%);
+--bg-aurora:      linear-gradient(135deg, #4338ca 0%, #7c3aed 50%, #ec4899 100%);
+--bg-noir:        #0a0a0f;
+
+/* Brand colors */
+--indigo-400:     #818cf8;
+--indigo-500:     #6366f1;
+--violet-500:     #8b5cf6;
+--purple-500:     #a855f7;
+--pink-500:       #ec4899;
+--amber-400:      #fbbf24;
+--green-400:      #34d399;
+--red-400:        #f87171;
+
+/* Surface tints */
+--card-bg:        #0f0f1f;
+--card-border:    rgba(255,255,255,0.08);
+--text-primary:   #f5f5f7;
+--text-secondary: #a1a1aa;
+--text-tertiary:  #52525b;
+
+/* Type scale */
+--display: 88px / 0.98 (titles)
+--h1: 42px / 1.05
+--h2: 28px / 1.2
+--body: 16px / 1.5
+--label: 12px / 1.3 (uppercase, letter-spacing 0.18em)
+--micro: 10px / 1.2 (footers)
+```
+
+# Density requirements
+
+Slides should be **DENSE**. A target slide has:
+- 15-30 distinct visual elements
+- 2-4 typographic levels
+- 3-6 decorated containers
+- At least one inline SVG decoration (curves, marks, accents)
+- A header (kicker + title) AND a footer (label + page number)
+
+Whitespace is fine, but every region of the slide should be doing visual work. Reject the temptation to leave half a slide empty.
+
+# Output format
+
+When asked to produce a corpus, write each slide as `slide-NN-{topic}.html` in the target directory (default `examples/corpus/`). NN is zero-padded to 2 digits. Number them sequentially.
+
+When asked to produce a single deck, concatenate all slides into one file separated by `<!DOCTYPE html>` boundaries (slidify will split it).
+
+# Self-check before delivering
+
+For every slide you write, mentally trace:
+1. Will the layout cluster cleanly? (avoid deep nesting > 5 levels)
+2. Is the title marked with `data-pptx-role="title"`?
+3. Does at least one element have a `data-slidify-decorate` hint?
+4. Are gradients multi-stop (≥2 stops, ideally 3) so OKLCH densification helps?
+5. Is the heaviest visual decoration done with NATIVE primitives (gradients, shadows, SVG paths) — not background images or filters?
+6. Does each piece of text fit its container at the CSS font size, with ~10% horizontal slack budget? (Inter is narrower than Liberation Sans/Calibri; if the line just barely fits in CSS, it WILL overflow when the substituted font renders.)
+
+Aim for slides that look like Linear, Vercel, Stripe, Apple keynote, Notion's homepage, or shadcn/ui marketing pages.

--- a/.gemini/skills/html-to-slides/SKILL.md
+++ b/.gemini/skills/html-to-slides/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: html-to-slides
+description: Convert HTML decks into editable PPTX with the `slidify` CLI. Trigger when the user asks to make a deck/presentation/slides from HTML, asks to convert HTML to PowerPoint, or has a directory of slide HTML files they want to ship as a .pptx. Use the bundled CLI (`slidify`) — it self-describes via `slidify manifest`, ships in-tree guides via `slidify guide`, and emits structured JSON via `--json`.
+---
+
+# html-to-slides
+
+Convert HTML slide decks into PPTX where the maximum possible fraction of the
+slide area is **editable PPTX primitives** (text frames, shapes, lines, native
+pictures), and only the irreducibly visual residue (gradients, complex SVGs,
+canvases) is rasterized.
+
+The work happens through the `slidify` CLI. This skill exists so a harness
+agent picks the right entry points and reads the right output fields, instead
+of reinventing them from scratch.
+
+## When to use this skill
+
+* User says "convert these HTML files to slides", "build a deck", "make a
+  PowerPoint from this HTML", "ship as PPTX", or similar.
+* User has a directory of `*.html` files or a single multi-slide HTML file.
+* User wants to author HTML decks for an LLM-generation pipeline that ends
+  in a `.pptx`.
+
+## When NOT to use this skill
+
+* User wants slides authored from scratch with no specific HTML in mind →
+  use the `slide-generator` agent first to produce HTML, then circle back
+  to this skill to convert.
+* User wants PDF, Google Slides, or Keynote output — slidify ships PPTX
+  only.
+
+## The CLI is self-describing
+
+Before doing anything, ask the CLI what it can do:
+
+```bash
+slidify manifest --brief        # one-line index of every command
+slidify manifest convert        # full spec for one command
+slidify guide                   # list of long-form guides
+slidify guide agent-quickstart  # the 60-second agent tour
+slidify doctor --json           # confirm the runtime environment
+```
+
+`slidify manifest` returns a stable JSON document that includes exit codes,
+env vars, examples, and the schema of `--json` payloads. **Read it once at
+session start** rather than guessing.
+
+## The standard recipe
+
+```bash
+# 1. Verify environment (one-shot at session start).
+slidify doctor --json
+
+# 2. Convert. Always pass --json for programmatic output.
+slidify convert deck.html deck.pptx --json --report-json /tmp/report.json
+
+# 3. Inspect outcome WITHOUT shelling out to jq.
+slidify field /tmp/report.json native_area_ratio
+slidify field /tmp/report.json editability_passed
+slidify field /tmp/report.json fidelity_reports.0.ssim
+```
+
+A successful `convert --json` returns a `ConversionResult` object plus a
+`_next` array of suggested follow-up commands tailored to that run. Read
+`_next` first — the CLI is telling you what to do.
+
+## Source forms
+
+`slidify convert <input> <output.pptx>` accepts:
+
+| `<input>`              | Behavior |
+|------------------------|----------|
+| `deck.html`            | Single file. Split on `<!DOCTYPE html>` for multi-slide. |
+| `slides/`              | Directory of `*.html` files, one slide each, sorted lexicographically. Name them `slide-01.html`, `slide-02.html`. |
+| `-`                    | Read HTML from stdin. Useful for one-off generation pipelines. |
+
+Examples:
+
+```bash
+slidify convert deck.html out.pptx --json
+slidify convert slides/   out.pptx --json
+echo "$HTML" | slidify convert - out.pptx --json
+```
+
+## Profiles
+
+```bash
+# Fast preview while iterating on HTML (no oracle, no LLM):
+slidify convert deck.html out.pptx --no-oracle --no-tier3 --json
+
+# Production emit (default — oracle on, LLM on if available):
+slidify convert deck.html out.pptx --json
+```
+
+## Authoring HTML well
+
+If the user is generating the HTML, ALWAYS read the authoring guide first:
+
+```bash
+slidify guide authoring                            # full text
+slidify guide authoring --toc                      # just headings
+slidify guide authoring --section "Hard contract"  # one section
+slidify guide authoring --grep "raster"            # search inside
+```
+
+The TL;DR:
+
+1. Single self-contained HTML file. Inline CSS only. No external stylesheets, no JS.
+2. Viewport is **exactly 1280×720 px**.
+3. One element per slide carries `data-pptx-role="title"`.
+4. Use the **Inter** font; slidify embeds it.
+5. Prefer native primitives: gradients, `box-shadow`, `border-radius`, inline SVG with `<rect>/<circle>/<path>`.
+6. Add `data-slidify-decorate="hero|spotlight|aurora|orbit|glass|tactile|recessed"` to ~3–6 elements per slide for layered native effects.
+7. Avoid `background-image: url(...)`, `filter: blur(...)`, `<canvas>`, `@font-face`, arbitrary `transform: rotate()`, and `<table>` (use CSS grid).
+
+For deeper authoring guidance, the `slide-generator` agent in this repo is
+tuned for slidify and will produce dense, native-emit-friendly HTML.
+
+## Reading the result
+
+```jsonc
+{
+  "pptx_path":            "deck.pptx",
+  "n_slides":             12,
+  "native_area_ratio":    0.873,    // ≥0.85 excellent, 0.6–0.85 ok, <0.6 audit
+  "pattern_coverage":     0.41,
+  "editability_passed":   true,     // false → shapes silently dropped
+  "editability_failing_slides": [],
+  "fidelity_reports":     [{"slide_index":0,"ssim":0.961,"ocr_recall":1.0,"passed":true}, ...],
+  "unmatched_signatures": [...],    // Tier-0 candidates for the harvester
+  "_next":                [...]     // concrete follow-up commands
+}
+```
+
+Decision rules for the agent:
+
+1. `editability_passed == false` → re-emit the failing slides individually,
+   or read `slidify guide troubleshooting --section "editability_passed"`.
+2. `native_area_ratio < 0.6` → the deck is mostly raster. Use
+   `slidify guide authoring --section "What forces a raster"` to find
+   common offenders, fix HTML, retry.
+3. `unmatched_signatures` non-empty AND user owns the corpus → suggest
+   running `slidify harvest <corpus_dir>` to surface new Tier-0 patterns.
+
+## Errors come with remediation
+
+Failed runs in `--json` mode return:
+
+```jsonc
+{
+  "error": "Executable doesn't exist at /opt/pw-browsers/...",
+  "type":  "PlaywrightError",
+  "stage": "convert",
+  "_remediation": [
+    "Run `slidify doctor` to verify Chromium is installed.",
+    "Install with: `playwright install chromium --with-deps`"
+  ]
+}
+```
+
+Read `_remediation`, perform the fix, retry. Do not paper over the error
+with extra `try/except` — surface it back to the user when remediation
+needs human input (credentials, package install, etc.).
+
+## Exit codes
+
+| Code | Meaning                                                         |
+|------|-----------------------------------------------------------------|
+| 0    | success                                                         |
+| 1    | doctor: required system dependency missing                      |
+| 2    | conversion error (input not found, render/LLM failure)          |
+| 3    | editability drift — shapes silently dropped from output         |
+
+## Environment
+
+The CLI works without API keys (tier-3 falls back to Raster). For best
+fidelity provide one of:
+
+* `ANTHROPIC_API_KEY` — `anthropic` backend
+* `GEMINI_API_KEY`    — `gemini-aistudio` backend
+* `GOOGLE_CLOUD_PROJECT` (+ `GOOGLE_CLOUD_LOCATION`) — Vertex backends
+
+Or steer with `SLIDIFY_LLM_BACKEND` / `SLIDIFY_LLM_MODEL` /
+`SLIDIFY_RENDER_CONCURRENCY` / `SLIDIFY_NO_ORACLE` / `SLIDIFY_NO_TIER3`.
+
+## Packaging / deployment
+
+If the host doesn't have LibreOffice / Tesseract / Chromium, run inside the
+slidify Docker image instead:
+
+```bash
+docker run --rm -v "$PWD":/work slidify:latest \
+       convert /work/deck.html /work/out.pptx --json
+```
+
+`slidify guide binary` describes the three packaging modes (Docker,
+PyInstaller onefile, hybrid bundle).
+
+## End-to-end agent loop
+
+```bash
+# 1. Verify environment.
+slidify doctor --json | slidify field /dev/stdin checks.0.ok    # required deps?
+
+# 2. Read the schema you'll be working with.
+slidify manifest convert > /tmp/spec.json
+
+# 3. Generate or receive HTML.
+# ... write deck.html ...
+
+# 4. Convert.
+slidify convert deck.html out.pptx --json --report-json /tmp/r.json
+
+# 5. Branch on outcome.
+EDIT_OK=$(slidify field /tmp/r.json editability_passed)
+NAR=$(slidify field /tmp/r.json native_area_ratio)
+# Decide: ship, re-emit, or refactor HTML.
+```
+
+That loop is the entire skill. Everything else is detail surfaced through
+`slidify guide`, `slidify manifest`, and the `_next` / `_remediation`
+fields in JSON output.

--- a/README.md
+++ b/README.md
@@ -13,18 +13,26 @@ area covered by native shapes — subject to perceptual fidelity floors
 
 ## Install
 
-System dependencies (Ubuntu / Debian):
+Three options, ranked by friction:
 
 ```bash
+# 1. Single-binary install (recommended for users) — first run auto-provisions
+#    a private Python 3.11 + Playwright Chromium under ~/.local/share/slidify/.
+curl -fsSL https://slidify.sh/install | sh
+slidify doctor
+
+# 2. Docker (most self-contained — bundles LibreOffice / Tesseract / fonts).
+docker build -f packaging/Dockerfile -t slidify:latest .
+docker run --rm -v "$PWD":/work slidify:latest convert /work/deck.html /work/deck.pptx
+
+# 3. From source (development).
 sudo apt-get install -y libreoffice-impress poppler-utils tesseract-ocr fonts-inter
-```
-
-Python deps + browser:
-
-```bash
 uv sync --extra dev
 uv run playwright install chromium --with-deps
 ```
+
+Verify with `slidify doctor`. See [`packaging/`](packaging/) for the full
+matrix (Rust bootstrap, Docker, PyInstaller bundle, pip).
 
 ## Use
 
@@ -36,7 +44,31 @@ slidify deck.html deck.pptx
 
 # Directory of per-slide files (sorted lexicographically — name them 01.html, 02.html, …)
 slidify slides/ deck.pptx
+
+# Stdin pipe (no temp files)
+cat deck.html | slidify convert - deck.pptx --json
 ```
+
+The CLI is designed to be self-describing — every command emits structured
+JSON, every error includes a `_remediation` block, every successful run
+includes a `_next` array of follow-up commands:
+
+```bash
+slidify doctor              # verify environment (LibreOffice, Chromium, …)
+slidify manifest --brief    # one-line index of every command
+slidify manifest convert    # full spec for one command (drill-down)
+slidify guide               # list of long-form guides
+slidify guide authoring     # how to author HTML for high native-area ratio
+slidify guide authoring --section "What forces a raster"   # section pluck
+slidify guide --search "tier 0"                            # cross-guide grep
+slidify field report.json native_area_ratio                # built-in jq-lite
+```
+
+Exit codes: `0` ok, `1` doctor missing deps, `2` conversion error, `3`
+editability drift (shapes silently dropped). For LLM agents, the
+[`html-to-slides` skill](.claude/skills/html-to-slides/SKILL.md) (mirrored
+under [`.gemini/`](.gemini/skills/html-to-slides/SKILL.md)) wraps the
+canonical agent loop.
 
 Python — `convert(source, pptx_path, config)` accepts five source forms:
 

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,0 +1,100 @@
+# slidify — production runtime image.
+#
+# Multi-stage:
+#   1. `builder` installs Python + Playwright + project, builds a wheel.
+#   2. `runtime` copies the wheel into a slim image with system deps
+#      (LibreOffice, Tesseract, poppler-utils, Inter font, Chromium).
+#
+# Build:
+#     docker build -f packaging/Dockerfile -t slidify:latest .
+#
+# Run:
+#     docker run --rm -v "$PWD":/work slidify:latest \
+#            convert /work/deck.html /work/out.pptx --json
+#
+# Verify:
+#     docker run --rm slidify:latest doctor
+
+ARG PYTHON_VERSION=3.11
+
+# ----------------------------------------------------------------------------
+# Stage 1 — builder
+# ----------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /build
+
+# Build deps (lxml, pillow native bits).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libxml2-dev libxslt1-dev zlib1g-dev libjpeg-dev \
+        curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (fast resolver) — keeps the image deterministic relative
+# to the lockfile.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    cp /root/.local/bin/uv /usr/local/bin/uv
+
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY slidify/ ./slidify/
+
+RUN uv build --wheel --out-dir /wheels
+
+# ----------------------------------------------------------------------------
+# Stage 2 — runtime
+# ----------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+    DEBIAN_FRONTEND=noninteractive
+
+# System runtime deps:
+#   * libreoffice-impress  — fidelity oracle (PPTX → PNG)
+#   * tesseract-ocr        — OCR recall checks
+#   * poppler-utils        — pdftoppm fallback path
+#   * fonts-inter          — default deck typeface
+#   * fonts-liberation,
+#     fonts-dejavu-core    — sensible substitutes for missing CSS families
+#   * libnss3, libxkbcommon0,
+#     libgbm1, libasound2,
+#     libpango-1.0-0,
+#     libcairo2, libxcomposite1,
+#     libxdamage1, libxfixes3,
+#     libxrandr2, libxshmfence1,
+#     libdrm2, libxext6, libxi6  — Chromium runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libreoffice-impress libreoffice-core \
+        tesseract-ocr \
+        poppler-utils \
+        fonts-inter fonts-liberation fonts-dejavu-core \
+        libnss3 libxkbcommon0 libgbm1 libasound2 \
+        libpango-1.0-0 libcairo2 libxcomposite1 libxdamage1 \
+        libxfixes3 libxrandr2 libxshmfence1 libdrm2 libxext6 libxi6 \
+        libatk1.0-0 libatk-bridge2.0-0 libcups2 libxss1 \
+        ca-certificates \
+    && fc-cache -f \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Install the slidify wheel from stage 1.
+COPY --from=builder /wheels/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+
+# Pre-install Playwright Chromium to a stable path so doctor finds it.
+RUN python -m playwright install chromium
+
+# Non-root user — LibreOffice writes a profile dir, so we give it $HOME.
+RUN useradd --create-home --shell /bin/bash slidify
+USER slidify
+WORKDIR /work
+
+# Default command: forward args to slidify.
+ENTRYPOINT ["slidify"]
+CMD ["--help"]

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,108 @@
+# Packaging slidify
+
+Four deployment targets, ranked by user-facing simplicity:
+
+| Mode                | User experience            | Self-contains              |
+|---------------------|----------------------------|----------------------------|
+| Rust bootstrap      | `curl … \| sh`             | Launcher only; auto-bootstraps Python + Playwright |
+| Docker image        | `docker run slidify`       | Everything (incl. LibreOffice) |
+| PyInstaller bundle  | Single ELF + apt deps      | Python + deps + Playwright |
+| `pip install`       | dev workflow               | Python deps only           |
+
+See `bootstrap-rust/` for the launcher. Brief comparison: the Rust bootstrap
+gives the smoothest install UX (one curl, < 5 MB) but cannot bundle
+LibreOffice / Tesseract / Chromium statically — those are still apt/brew
+installs (or skipped via `--no-oracle`). The Docker image is the only mode
+that's truly self-contained, at the cost of a ~1.6 GB image.
+
+## 1. Rust bootstrap — best UX
+
+```bash
+curl -fsSL https://slidify.sh/install | sh
+slidify doctor
+```
+
+A < 5 MB static Rust binary lands in `~/.local/bin/slidify`. First run
+materializes a private Python 3.11 + slidify + Playwright Chromium under
+`~/.local/share/slidify/`. From then on, invocations exec the real CLI
+immediately — argv, exit codes, JSON output are identical to a
+`pip install slidify`. See `bootstrap-rust/`.
+
+## 2. Docker image — most self-contained
+
+```bash
+docker build -f packaging/Dockerfile -t slidify:latest .
+docker run --rm -v "$PWD":/work slidify:latest \
+       convert /work/deck.html /work/deck.pptx --json
+```
+
+Verify:
+
+```bash
+docker run --rm slidify:latest doctor
+```
+
+The image is ~1.6 GB (LibreOffice dominates). If you need to push to a
+registry behind a slow link, the multi-stage build keeps the runtime layer
+free of the wheel-build toolchain.
+
+## 3. PyInstaller binary
+
+For Linux fleets where `pip install` is blocked but apt is available:
+
+```bash
+./packaging/build-binary.sh                  # → dist/slidify  (~80 MB)
+./packaging/build-binary.sh --with-chromium  # + dist/slidify-chromium.tar.gz
+./packaging/build-binary.sh --with-deps      # + dist/slidify-bundle.tar.gz
+```
+
+`dist/slidify` is a single ELF that bundles:
+
+* CPython 3.11 and every Python dependency
+* Playwright driver (downloads Chromium on first run unless bundled)
+* slidify package data (patterns YAML, guides, tailwind catalog)
+
+It does NOT bundle LibreOffice / Tesseract / poppler — those must exist
+on the host. Run `./dist/slidify doctor` to verify.
+
+`--with-deps` produces `dist/slidify-bundle.tar.gz` containing the ELF plus
+`.deb` files and a one-liner installer; ship it to nodes that can't reach
+package repositories.
+
+## 4. `pip install`
+
+```bash
+pip install slidify
+playwright install chromium --with-deps
+sudo apt-get install -y libreoffice-impress tesseract-ocr poppler-utils fonts-inter
+slidify doctor
+```
+
+For development:
+
+```bash
+uv sync --extra dev
+uv run playwright install chromium --with-deps
+uv run slidify doctor
+```
+
+## Verifying any deployment
+
+`slidify doctor` is the canonical health check. It exits non-zero when a
+required dependency is missing, and `--json` makes it machine-friendly:
+
+```bash
+slidify doctor --json | slidify field /dev/stdin checks.0.ok
+```
+
+## Why no PyOxidizer / Nuitka onefile?
+
+Both work in principle. We chose PyInstaller because:
+
+1. The `playwright._impl._driver` extension is reliably picked up.
+2. `slidify.patterns.data/*.yaml` is trivial to bundle as data.
+3. The runtime extracts to a tmpfs, which is fine in containers and CI.
+
+If you have a strict reason to use Nuitka or PyOxidizer (smaller binary,
+true static linking), the `slidify.spec` file is a clean reference for
+what needs to be bundled. Both targets are PRs we'd happily review.

--- a/packaging/bootstrap-rust/Cargo.toml
+++ b/packaging/bootstrap-rust/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "slidify-bootstrap"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Single-binary bootstrap launcher for slidify (HTML→PPTX). On first run, materializes a private Python venv with slidify + Playwright Chromium, then execs the real CLI for every subsequent invocation."
+
+# Static musl build for Linux:
+#   cargo build --release --target x86_64-unknown-linux-musl
+# Universal macOS build:
+#   cargo build --release --target aarch64-apple-darwin
+#   cargo build --release --target x86_64-apple-darwin
+# The resulting binary is < 5 MB.
+
+[[bin]]
+name = "slidify"
+path = "src/main.rs"
+
+[profile.release]
+lto = true
+codegen-units = 1
+opt-level = "z"
+strip = true
+panic = "abort"
+
+[dependencies]
+anyhow = "1"
+dirs = "5"
+ureq = { version = "2", features = ["tls"] }
+sha2 = "0.10"
+hex = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/packaging/bootstrap-rust/README.md
+++ b/packaging/bootstrap-rust/README.md
@@ -1,0 +1,82 @@
+# slidify-bootstrap
+
+Single static Rust binary that gives users a one-liner install for slidify
+without committing to Docker.
+
+```bash
+curl -fsSL https://slidify.sh/install | sh
+```
+
+Drops a < 5 MB launcher into `~/.local/bin/slidify`. First run materializes
+a private Python 3.11 + slidify + Playwright Chromium under
+`~/.local/share/slidify/`. Steady-state invocations exec straight through
+to the real CLI — argv, exit codes and JSON output are identical to a
+`pip install slidify`.
+
+## Why a launcher, not a full Rust rewrite?
+
+slidify orchestrates two heavy native dependencies that no language can
+inline into a static binary:
+
+* **Chromium** (~150 MB compressed) — Playwright drives it as a child
+  process. Its own runtime needs `libnss`, `libxkbcommon`, `libgbm`, etc.
+* **LibreOffice** (~500 MB) — invoked headlessly for the SSIM oracle.
+
+Even a complete Rust rewrite of the slidify pipeline would still spawn
+Chromium and LibreOffice as subprocesses. So the right level for a
+"single binary install" abstraction is a **bootstrap launcher** — exactly
+the pattern `rustup`, `bun`, and `uv` use.
+
+## Lifecycle
+
+```
+$ slidify deck.html out.pptx       # first invocation
+slidify: first-run setup → /home/me/.local/share/slidify
+[ uv → Python 3.11 → slidify wheel → Playwright Chromium ]
+slidify: setup complete.
+slidify: hint — run `slidify doctor` to verify system deps
+[ runs the conversion ]
+
+$ slidify deck.html out.pptx       # every subsequent invocation
+[ runs the conversion immediately — no provisioning ]
+```
+
+## Subcommands handled by the bootstrap itself
+
+| Command             | Effect                                                      |
+|---------------------|-------------------------------------------------------------|
+| `slidify setup`     | Provision the private slidify env (idempotent)              |
+| `slidify upgrade`   | Re-provision at the latest version                          |
+| `slidify uninstall` | Remove the private slidify env (keeps the launcher binary)  |
+| `slidify where`     | Print `$SLIDIFY_HOME`                                       |
+
+Every other argv is forwarded verbatim to the real `slidify` CLI.
+
+## Build
+
+```bash
+cargo build --release --target x86_64-unknown-linux-musl
+cargo build --release --target aarch64-unknown-linux-musl
+cargo build --release --target aarch64-apple-darwin
+cargo build --release --target x86_64-apple-darwin
+```
+
+CI uploads the four artifacts as
+`slidify-{x86_64-unknown-linux-musl,aarch64-apple-darwin,…}` to a GitHub
+release; `install.sh` resolves the right one via `uname -s -m`.
+
+## What still requires the OS package manager
+
+`slidify doctor` will flag these if missing — they're not bundled because
+they're either too large (LibreOffice) or carry their own runtime
+dependencies (Tesseract):
+
+| Dep             | Debian                             | macOS              |
+|-----------------|------------------------------------|--------------------|
+| LibreOffice     | `apt-get install libreoffice-impress` | `brew install --cask libreoffice` |
+| Tesseract       | `apt-get install tesseract-ocr`    | `brew install tesseract`           |
+| poppler-utils   | `apt-get install poppler-utils`    | `brew install poppler`             |
+| Inter font      | `apt-get install fonts-inter`      | install via Font Book              |
+
+The `--no-oracle` flag bypasses the LibreOffice / Tesseract / poppler
+requirement (you keep `convert`, lose the SSIM/OCR fidelity check).

--- a/packaging/bootstrap-rust/install.sh
+++ b/packaging/bootstrap-rust/install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+# slidify — single-binary installer.
+#
+#     curl -fsSL https://slidify.sh/install | sh
+#
+# Detects platform, downloads the matching slidify-bootstrap binary,
+# drops it into ~/.local/bin/slidify, and runs `slidify setup`. From
+# then on, `slidify` works just like the pip-installed CLI.
+#
+# Honors:
+#   SLIDIFY_INSTALL_DIR   — override install directory (default ~/.local/bin)
+#   SLIDIFY_BOOTSTRAP_VER — pin a bootstrap binary version
+#   SLIDIFY_NO_SETUP=1    — install the launcher only, skip env provisioning
+
+set -eu
+
+REPO_BASE="${SLIDIFY_REPO_BASE:-https://github.com/vamsiramakrishnan/pixelpitch/releases}"
+VERSION="${SLIDIFY_BOOTSTRAP_VER:-latest}"
+INSTALL_DIR="${SLIDIFY_INSTALL_DIR:-$HOME/.local/bin}"
+
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+case "$uname_s-$uname_m" in
+    Linux-x86_64)   target="x86_64-unknown-linux-musl" ;;
+    Linux-aarch64)  target="aarch64-unknown-linux-musl" ;;
+    Darwin-arm64)   target="aarch64-apple-darwin" ;;
+    Darwin-x86_64)  target="x86_64-apple-darwin" ;;
+    *)
+        echo "slidify-install: unsupported platform $uname_s-$uname_m" >&2
+        exit 2 ;;
+esac
+
+case "$VERSION" in
+    latest) url="$REPO_BASE/latest/download/slidify-$target" ;;
+    *)      url="$REPO_BASE/download/$VERSION/slidify-$target" ;;
+esac
+
+mkdir -p "$INSTALL_DIR"
+echo "Downloading $url ..."
+if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$INSTALL_DIR/slidify"
+elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$INSTALL_DIR/slidify" "$url"
+else
+    echo "slidify-install: need curl or wget" >&2
+    exit 2
+fi
+chmod +x "$INSTALL_DIR/slidify"
+
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *) echo
+       echo "Note: $INSTALL_DIR is not on your PATH."
+       echo "Add it: echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.profile"
+       ;;
+esac
+
+if [ "${SLIDIFY_NO_SETUP:-}" != "1" ]; then
+    echo "Provisioning slidify environment ..."
+    "$INSTALL_DIR/slidify" setup
+fi
+
+echo
+echo "Installed: $INSTALL_DIR/slidify"
+echo "Try:       slidify doctor"

--- a/packaging/bootstrap-rust/src/main.rs
+++ b/packaging/bootstrap-rust/src/main.rs
@@ -1,0 +1,225 @@
+// slidify-bootstrap — single static binary that materializes a private
+// slidify environment on first run and execs the real CLI thereafter.
+//
+// Lifecycle:
+//
+//   1. The user installs us via `curl -fsSL https://slidify.sh/install | sh`.
+//      The install script drops this binary into ~/.local/bin/slidify.
+//
+//   2. First invocation: we look for `$SLIDIFY_HOME/env/bin/slidify`. If
+//      missing, we provision it: download a portable uv, materialize a
+//      pinned Python 3.11, pip-install slidify + the playwright wheel,
+//      then `playwright install chromium`. All under ~/.local/share/slidify/.
+//
+//   3. Steady state: we exec ~/.local/share/slidify/env/bin/slidify with
+//      the user's argv unchanged, so the experience is identical to the
+//      pip-installed CLI.
+//
+//   4. `slidify upgrade` re-runs provisioning at the latest version.
+//
+// This is the "rustup model": tiny, single-binary, but doesn't pretend
+// to bundle Chromium or LibreOffice (it can't — they're hundreds of MB
+// of native code with their own dynamic dependencies). Instead it makes
+// installation a one-liner and surfaces missing system deps clearly.
+//
+// LibreOffice / Tesseract / poppler remain explicit OS-package
+// dependencies. The bootstrap prints a precise apt/brew install line
+// when it sees them missing.
+
+use anyhow::{anyhow, Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn slidify_home() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("SLIDIFY_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    let data = dirs::data_dir().ok_or_else(|| anyhow!("no XDG data dir"))?;
+    Ok(data.join("slidify"))
+}
+
+fn target_cli(home: &Path) -> PathBuf {
+    home.join("env").join("bin").join("slidify")
+}
+
+fn provision(home: &Path) -> Result<()> {
+    eprintln!("slidify: first-run setup → {}", home.display());
+
+    std::fs::create_dir_all(home).context("creating SLIDIFY_HOME")?;
+
+    // 1. Ensure uv is on PATH (or fetch a portable copy).
+    let uv = which("uv").or_else(|_| install_uv(home))?;
+
+    // 2. Create a pinned Python 3.11 venv under $SLIDIFY_HOME/env.
+    let env_dir = home.join("env");
+    if !env_dir.exists() {
+        run(&uv, &["venv", "--python", "3.11", env_dir.to_str().unwrap()])?;
+    }
+
+    // 3. Install slidify into the venv. Pin via SLIDIFY_PIN for repro builds.
+    let pin = std::env::var("SLIDIFY_PIN").unwrap_or_else(|_| "slidify".into());
+    run_with_env(
+        &uv,
+        &["pip", "install", "--python", env_dir.join("bin/python").to_str().unwrap(), &pin],
+        &[("VIRTUAL_ENV", env_dir.to_str().unwrap())],
+    )?;
+
+    // 4. Install Playwright Chromium under a stable path.
+    let pw_browsers = home.join("pw-browsers");
+    std::fs::create_dir_all(&pw_browsers).ok();
+    run_with_env(
+        env_dir.join("bin/python").to_str().unwrap(),
+        &["-m", "playwright", "install", "chromium"],
+        &[("PLAYWRIGHT_BROWSERS_PATH", pw_browsers.to_str().unwrap())],
+    )?;
+
+    eprintln!("slidify: setup complete.");
+    eprintln!("slidify: hint — run `slidify doctor` to verify system deps");
+    eprintln!("         (LibreOffice, Tesseract, poppler-utils, fonts-inter).");
+    Ok(())
+}
+
+fn install_uv(home: &Path) -> Result<PathBuf> {
+    let bin_dir = home.join("bin");
+    std::fs::create_dir_all(&bin_dir)?;
+    let uv_path = bin_dir.join("uv");
+    if uv_path.exists() {
+        return Ok(uv_path);
+    }
+
+    eprintln!("slidify: downloading uv (one-shot, < 20 MB) …");
+    let installer_url = "https://astral.sh/uv/install.sh";
+    let body = ureq::get(installer_url).call()?.into_string()?;
+    // Run the installer with a pinned target dir.
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg(&body)
+        .env("UV_INSTALL_DIR", &bin_dir)
+        .status()
+        .context("running uv install.sh")?;
+    if !status.success() {
+        return Err(anyhow!("uv installer exited with {status}"));
+    }
+    if !uv_path.exists() {
+        return Err(anyhow!("uv installer did not produce {:?}", uv_path));
+    }
+    Ok(uv_path)
+}
+
+fn which<S: AsRef<str>>(bin: S) -> Result<PathBuf> {
+    let path_var = std::env::var_os("PATH").ok_or_else(|| anyhow!("no PATH"))?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(bin.as_ref());
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err(anyhow!("{} not on PATH", bin.as_ref()))
+}
+
+fn run<P: AsRef<Path>>(prog: P, args: &[&str]) -> Result<()> {
+    let status = Command::new(prog.as_ref()).args(args).status()?;
+    if !status.success() {
+        return Err(anyhow!("{:?} exited with {status}", prog.as_ref()));
+    }
+    Ok(())
+}
+
+fn run_with_env<P: AsRef<Path>>(prog: P, args: &[&str], env: &[(&str, &str)]) -> Result<()> {
+    let mut cmd = Command::new(prog.as_ref());
+    cmd.args(args);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(anyhow!("{:?} exited with {status}", prog.as_ref()));
+    }
+    Ok(())
+}
+
+fn print_help() {
+    eprintln!(
+        "slidify-bootstrap {VERSION} — launcher for the slidify CLI
+
+Subcommands handled by the bootstrap itself:
+  setup     Provision the private slidify env (idempotent).
+  upgrade   Re-provision at the latest version.
+  uninstall Remove the private slidify env (does NOT delete this binary).
+  where     Print SLIDIFY_HOME.
+
+Every other argv is forwarded verbatim to the real `slidify` CLI.
+First run auto-provisions; subsequent runs exec straight through.
+Set SLIDIFY_HOME to override the default (~/.local/share/slidify).
+"
+    );
+}
+
+fn main() -> ExitCode {
+    let home = match slidify_home() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("slidify: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    // Bootstrap-only subcommands.
+    if let Some(first) = args.first() {
+        match first.as_str() {
+            "--bootstrap-help" | "--launcher-help" => {
+                print_help();
+                return ExitCode::SUCCESS;
+            }
+            "where" => {
+                println!("{}", home.display());
+                return ExitCode::SUCCESS;
+            }
+            "uninstall" => {
+                if home.exists() {
+                    let _ = std::fs::remove_dir_all(&home);
+                }
+                eprintln!("Removed {}.", home.display());
+                eprintln!("This launcher binary is still in place; rm it manually if desired.");
+                return ExitCode::SUCCESS;
+            }
+            "setup" | "upgrade" => {
+                if let Err(e) = provision(&home) {
+                    eprintln!("slidify: provisioning failed: {e:#}");
+                    return ExitCode::from(1);
+                }
+                return ExitCode::SUCCESS;
+            }
+            _ => {}
+        }
+    }
+
+    let cli = target_cli(&home);
+    if !cli.exists() {
+        if let Err(e) = provision(&home) {
+            eprintln!("slidify: provisioning failed: {e:#}");
+            return ExitCode::from(1);
+        }
+    }
+
+    // Inject PLAYWRIGHT_BROWSERS_PATH if we own it but the user hasn't.
+    let pw = home.join("pw-browsers");
+    if std::env::var_os("PLAYWRIGHT_BROWSERS_PATH").is_none() && pw.exists() {
+        std::env::set_var("PLAYWRIGHT_BROWSERS_PATH", &pw);
+    }
+
+    // exec the real CLI.
+    let status = match Command::new(&cli).args(&args).status() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("slidify: failed to spawn {}: {e}", cli.display());
+            return ExitCode::from(1);
+        }
+    };
+
+    ExitCode::from(status.code().unwrap_or(1) as u8)
+}

--- a/packaging/build-binary.sh
+++ b/packaging/build-binary.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Build a self-contained slidify binary.
+#
+# Modes:
+#   ./packaging/build-binary.sh              # ELF only (no Chromium / OS deps)
+#   ./packaging/build-binary.sh --with-chromium
+#                                            # ELF + Playwright Chromium tarball
+#   ./packaging/build-binary.sh --with-deps  # ELF + .deb tarball of system deps
+#
+# Output goes under `dist/`:
+#   dist/slidify                 (always — the ELF)
+#   dist/slidify-chromium.tar.gz (with --with-chromium)
+#   dist/slidify-bundle.tar.gz   (with --with-deps)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+WITH_CHROMIUM=0
+WITH_DEPS=0
+for arg in "$@"; do
+    case "$arg" in
+        --with-chromium) WITH_CHROMIUM=1 ;;
+        --with-deps)     WITH_DEPS=1 ;;
+        -h|--help)
+            head -n 14 "$0" | sed 's/^# *//'
+            exit 0 ;;
+        *)
+            echo "build-binary.sh: unknown flag: $arg" >&2
+            exit 2 ;;
+    esac
+done
+
+echo "==> Ensuring uv environment is current"
+uv sync --extra dev
+
+echo "==> Ensuring PyInstaller is installed"
+uv pip install --quiet pyinstaller
+
+echo "==> Building ELF"
+rm -rf build dist
+uv run pyinstaller packaging/slidify.spec --clean --noconfirm
+test -x dist/slidify
+
+echo "==> Smoke-testing the binary"
+./dist/slidify version
+./dist/slidify manifest --brief > /dev/null
+./dist/slidify guide > /dev/null
+
+if [[ "$WITH_CHROMIUM" -eq 1 ]]; then
+    echo "==> Bundling Playwright Chromium"
+    uv run playwright install chromium
+    BROWSERS_DIR="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+    if [[ ! -d "$BROWSERS_DIR" ]]; then
+        echo "Chromium dir not found at $BROWSERS_DIR" >&2
+        exit 1
+    fi
+    tar -C "$BROWSERS_DIR" -czf dist/slidify-chromium.tar.gz .
+    echo "Wrote dist/slidify-chromium.tar.gz ($(du -h dist/slidify-chromium.tar.gz | cut -f1))"
+fi
+
+if [[ "$WITH_DEPS" -eq 1 ]]; then
+    if ! command -v apt-get >/dev/null; then
+        echo "--with-deps only supported on Debian/Ubuntu hosts." >&2
+        exit 1
+    fi
+    echo "==> Downloading .deb files for system dependencies"
+    DEPS_DIR="$(mktemp -d)"
+    pushd "$DEPS_DIR" >/dev/null
+    apt-get download \
+        libreoffice-impress libreoffice-core \
+        tesseract-ocr poppler-utils \
+        fonts-inter fonts-liberation
+    popd >/dev/null
+
+    BUNDLE_DIR="$(mktemp -d)"
+    cp dist/slidify "$BUNDLE_DIR/"
+    cp -r "$DEPS_DIR" "$BUNDLE_DIR/deps"
+    cat > "$BUNDLE_DIR/install.sh" <<'INSTALL_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+sudo dpkg -i "$HERE"/deps/*.deb || sudo apt-get install -fy
+sudo install -m 0755 "$HERE/slidify" /usr/local/bin/slidify
+echo "Installed slidify to /usr/local/bin/slidify"
+slidify doctor
+INSTALL_EOF
+    chmod +x "$BUNDLE_DIR/install.sh"
+    tar -C "$BUNDLE_DIR" -czf dist/slidify-bundle.tar.gz .
+    rm -rf "$BUNDLE_DIR" "$DEPS_DIR"
+    echo "Wrote dist/slidify-bundle.tar.gz ($(du -h dist/slidify-bundle.tar.gz | cut -f1))"
+fi
+
+echo
+echo "Done."
+echo "  dist/slidify ($(du -h dist/slidify | cut -f1))"
+echo "Run \`./dist/slidify doctor\` to verify the host environment."

--- a/packaging/slidify.spec
+++ b/packaging/slidify.spec
@@ -1,0 +1,105 @@
+# PyInstaller spec for slidify.
+#
+# Produces a single ELF (`dist/slidify`) that bundles Python 3.11, every
+# Python dependency, the slidify package data (patterns YAML, guides,
+# tailwind catalog), and the Playwright driver. Chromium is *downloaded*
+# on first run if PLAYWRIGHT_BROWSERS_PATH is unset.
+#
+# Build (preferred path — invokes the wrapper that also resolves Playwright):
+#     ./packaging/build-binary.sh
+#
+# Build directly (skips Chromium-bundle option):
+#     pyinstaller packaging/slidify.spec --clean
+#
+# This binary does NOT include LibreOffice / tesseract / poppler — those
+# remain host responsibilities. `slidify doctor` flags them when missing.
+
+# ruff: noqa: F821 — PyInstaller injects `Analysis`, `EXE`, etc. at exec time.
+
+import sys
+from pathlib import Path
+
+block_cipher = None
+
+ROOT = Path.cwd()
+
+# Bundle slidify's package data so the running binary can read it
+# without falling back to the source tree.
+datas = [
+    (str(ROOT / "slidify" / "patterns" / "data"), "slidify/patterns/data"),
+    (str(ROOT / "slidify" / "guides"),            "slidify/guides"),
+]
+
+# Optionally bundle Playwright driver so the binary works without
+# `pip install playwright`. We pull the driver path lazily so this
+# spec stays importable on machines that don't have playwright.
+try:
+    from playwright._impl._driver import compute_driver_executable
+
+    drv = Path(compute_driver_executable()[0]).parent
+    datas.append((str(drv), "playwright/driver"))
+except Exception:
+    pass
+
+# Hidden imports — modules pulled in via importlib that PyInstaller's
+# static analyzer misses.
+hiddenimports = [
+    "slidify.classifier.tier1",
+    "slidify.classifier.tier2",
+    "slidify.classifier.tier3",
+    "slidify.classifier.llm",
+    "slidify.patterns",
+    "slidify.patterns.matcher",
+    "slidify.patterns.recipes",
+    "slidify.patterns.signatures",
+    "slidify.patterns.tailwind",
+    "anthropic",
+    "google.genai",
+    "google.cloud.aiplatform",
+    "structlog",
+    "diskcache",
+    "pytesseract",
+    "skimage.metrics",
+]
+
+a = Analysis(
+    [str(ROOT / "slidify" / "cli.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[
+        # Heavy ML / scientific extras pulled in by deps but unused by slidify.
+        "matplotlib", "tkinter", "IPython", "jupyter",
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="slidify",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ packages = ["slidify"]
 [tool.hatch.build.targets.wheel.force-include]
 "slidify/patterns/data/tailwind.json" = "slidify/patterns/data/tailwind.json"
 "slidify/patterns/data/patterns.yaml" = "slidify/patterns/data/patterns.yaml"
+"slidify/guides/authoring.md" = "slidify/guides/authoring.md"
+"slidify/guides/agent-quickstart.md" = "slidify/guides/agent-quickstart.md"
+"slidify/guides/troubleshooting.md" = "slidify/guides/troubleshooting.md"
+"slidify/guides/binary.md" = "slidify/guides/binary.md"
+"slidify/guides/api.md" = "slidify/guides/api.md"
 
 [tool.ruff]
 line-length = 100

--- a/slidify/__init__.py
+++ b/slidify/__init__.py
@@ -1,6 +1,40 @@
-"""slidify — render-and-classify HTML to PPTX conversion."""
+"""slidify — render-and-classify HTML to PPTX conversion.
 
-from slidify.api import ConversionConfig, ConversionResult, convert
+Public API:
 
-__all__ = ["ConversionConfig", "ConversionResult", "convert"]
+    from slidify import convert, convert_sync, ConversionConfig, ConversionResult
+
+    cfg = ConversionConfig.fast()              # latency-first profile
+    result = convert_sync("deck.html", "deck.pptx", cfg)
+
+`convert` is the async entrypoint, `convert_sync` a wrapper for plain scripts.
+For containers and CI, ``ConversionConfig.from_env()`` reads ``SLIDIFY_*`` env
+vars (see its docstring).
+"""
+
+from slidify.api import (
+    ConversionConfig,
+    ConversionResult,
+    convert,
+    convert_sync,
+)
+from slidify.exceptions import (
+    ClassificationError,
+    EmitError,
+    OracleError,
+    RenderError,
+    SlidifyError,
+)
+
+__all__ = [
+    "ClassificationError",
+    "ConversionConfig",
+    "ConversionResult",
+    "EmitError",
+    "OracleError",
+    "RenderError",
+    "SlidifyError",
+    "convert",
+    "convert_sync",
+]
 __version__ = "0.1.0"

--- a/slidify/api.py
+++ b/slidify/api.py
@@ -85,6 +85,10 @@ class ConversionConfig:
             the auto-correction loop can re-emit failing slides natively.
             Set False on huge decks to drop plan state right after emit and
             rely on a single oracle pass without auto-correction.
+
+    Use `ConversionConfig.fast()` for the lowest-latency configuration
+    (no oracle, no LLM); `ConversionConfig.from_env()` reads SLIDIFY_*
+    environment variables (handy for containers and CI).
     """
 
     viewport: tuple[int, int] = (SLIDE_W_PX, SLIDE_H_PX)
@@ -120,6 +124,65 @@ class ConversionConfig:
     # checks pixels, so a missing-but-pixel-similar shape passes).
     # Cheap (~1ms/slide); on by default.
     run_editability_check: bool = True
+
+    # ---- Constructors ------------------------------------------------------
+
+    @classmethod
+    def fast(cls) -> ConversionConfig:
+        """Lowest-latency profile: no oracle, no LLM, no editability check.
+
+        Suitable for previewing decks while iterating on HTML — drops every
+        post-emit verification pass so wall-clock time scales linearly with
+        the number of slides.
+        """
+        return cls(
+            run_oracle=False,
+            run_tier3=False,
+            run_editability_check=False,
+            keep_plans_for_oracle=False,
+        )
+
+    @classmethod
+    def from_env(cls) -> ConversionConfig:
+        """Build a config from `SLIDIFY_*` environment variables.
+
+        Recognized variables (all optional):
+
+        * ``SLIDIFY_NO_ORACLE=1``         — disable the fidelity oracle.
+        * ``SLIDIFY_NO_TIER3=1``          — disable the LLM adjudicator.
+        * ``SLIDIFY_LOW_MEMORY=1``        — drop per-slide state after emit.
+        * ``SLIDIFY_NO_FONTS=1``          — skip font embedding.
+        * ``SLIDIFY_LLM_BACKEND``         — override backend selection.
+        * ``SLIDIFY_LLM_MODEL``           — override model name.
+        * ``SLIDIFY_RENDER_CONCURRENCY``  — int, default 4.
+
+        Vertex credentials read directly from ``GOOGLE_CLOUD_PROJECT`` /
+        ``GOOGLE_CLOUD_LOCATION`` (the canonical names; we don't shadow them).
+        """
+        import os
+
+        def _flag(name: str) -> bool:
+            return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+        cfg = cls()
+        if _flag("SLIDIFY_NO_ORACLE"):
+            cfg.run_oracle = False
+        if _flag("SLIDIFY_NO_TIER3"):
+            cfg.run_tier3 = False
+        if _flag("SLIDIFY_LOW_MEMORY"):
+            cfg.keep_plans_for_oracle = False
+        if _flag("SLIDIFY_NO_FONTS"):
+            cfg.embed_fonts = False
+        if backend := os.environ.get("SLIDIFY_LLM_BACKEND"):
+            cfg.llm_backend = backend
+        if model := os.environ.get("SLIDIFY_LLM_MODEL"):
+            cfg.llm_model = model
+        if rc := os.environ.get("SLIDIFY_RENDER_CONCURRENCY"):
+            try:
+                cfg.render_concurrency = max(1, int(rc))
+            except ValueError:
+                pass
+        return cfg
 
 
 @dataclass
@@ -408,6 +471,27 @@ async def _drain_in_batches(
 # -----------------------------------------------------------------------------
 # Public API
 # -----------------------------------------------------------------------------
+
+
+def convert_sync(
+    source: SlideSource,
+    pptx_path: str | Path,
+    config: ConversionConfig | None = None,
+) -> ConversionResult:
+    """Synchronous wrapper around :func:`convert`.
+
+    Convenient for scripts and notebook cells that don't already run an
+    asyncio event loop. Will raise ``RuntimeError`` if called from inside
+    one — use :func:`convert` directly there.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(convert(source, pptx_path, config))
+    raise RuntimeError(
+        "convert_sync() cannot be called from a running event loop; "
+        "use `await convert(...)` instead."
+    )
 
 
 async def convert(

--- a/slidify/cli.py
+++ b/slidify/cli.py
@@ -1,9 +1,13 @@
 """slidify CLI entrypoints.
 
-Two subcommands:
+Subcommands:
 
-  slidify convert <input> <output.pptx>    one-shot conversion
-  slidify harvest <dir>                     run a corpus, emit pattern suggestions
+  slidify convert     <input> <output.pptx>     one-shot conversion
+  slidify harvest     <dir>                     run a corpus, emit pattern suggestions
+  slidify compat                                CSS/HTML compatibility matrix
+  slidify capture-gif <html>                    HTML animation → animated GIF
+  slidify doctor                                check system dependencies
+  slidify version                               print version info
 
 For backward compatibility, calling `slidify <input> <output.pptx>` (without a
 subcommand) defaults to `convert`.
@@ -13,11 +17,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
 import sys
 from pathlib import Path
 
 import click
 
+from slidify import __version__
 from slidify.api import ConversionConfig, convert
 from slidify.models import UnmatchedSignature
 
@@ -28,6 +34,16 @@ from slidify.models import UnmatchedSignature
 
 def _convert_options(fn):
     """Shared options between the explicit convert subcommand and the default."""
+    fn = click.option(
+        "--json", "json_out",
+        is_flag=True,
+        help="Print the full ConversionResult as JSON to stdout. Implies --quiet.",
+    )(fn)
+    fn = click.option(
+        "--quiet", "-q",
+        is_flag=True,
+        help="Suppress the human summary; print only the output path.",
+    )(fn)
     fn = click.option("--report-json", type=click.Path(dir_okay=False, path_type=Path), default=None)(fn)
     fn = click.option(
         "--no-differential-render",
@@ -67,6 +83,17 @@ def _convert_options(fn):
     return fn
 
 
+def _read_stdin_html() -> str:
+    """Read HTML from stdin (used when input path is `-`)."""
+    if sys.stdin.isatty():
+        click.echo(
+            "slidify: input '-' but stdin is a TTY; pipe HTML or pass a path.",
+            err=True,
+        )
+        sys.exit(2)
+    return sys.stdin.read()
+
+
 def _run_convert(
     input_path: Path,
     output_pptx: Path,
@@ -81,6 +108,8 @@ def _run_convert(
     no_differential_render: bool,
     no_embed_fonts: bool,
     report_json: Path | None,
+    quiet: bool,
+    json_out: bool,
 ) -> None:
     cfg = ConversionConfig(
         run_tier3=not no_tier3,
@@ -94,46 +123,183 @@ def _run_convert(
         differential_render=not no_differential_render,
         embed_fonts=not no_embed_fonts,
     )
-    result = asyncio.run(convert(input_path, output_pptx, cfg))
 
-    click.echo(f"Wrote: {result.pptx_path}")
-    click.echo(f"Slides: {result.n_slides}")
-    click.echo(f"Native area ratio: {result.native_area_ratio:.3f}")
-    click.echo(f"Pattern coverage: {result.pattern_coverage:.3f}")
+    # Stdin input: `slidify convert - out.pptx` reads the deck from stdin.
+    source: Path | str
+    if str(input_path) == "-":
+        source = _read_stdin_html()
+    else:
+        if not input_path.exists():
+            msg = f"input path does not exist: {input_path}"
+            if json_out:
+                click.echo(json.dumps({"error": msg, "type": "FileNotFoundError"}, indent=2))
+            else:
+                click.echo(click.style(f"slidify: {msg}", fg="red"), err=True)
+            sys.exit(2)
+        source = input_path
+
+    try:
+        result = asyncio.run(convert(source, output_pptx, cfg))
+    except Exception as e:
+        remediation = _error_remediation(e)
+        if json_out:
+            click.echo(json.dumps({
+                "error": str(e),
+                "type": type(e).__name__,
+                "stage": "convert",
+                "_remediation": remediation,
+            }, indent=2))
+        else:
+            click.echo(click.style(f"slidify: conversion failed: {e}", fg="red"), err=True)
+            for r in remediation:
+                click.echo(click.style("  → ", dim=True) + r, err=True)
+        sys.exit(2)
+
+    if json_out:
+        # Augment with `_next` hints so an LLM agent gets concrete
+        # follow-up commands without re-reading the manifest.
+        payload = result.model_dump()
+        payload["_next"] = _next_steps(result)
+        click.echo(json.dumps(payload, indent=2, default=str))
+    elif quiet:
+        click.echo(str(result.pptx_path))
+    else:
+        _print_summary(result)
+        _print_next_steps(result)
+
+    if report_json:
+        report_json.write_text(result.model_dump_json(indent=2), encoding="utf-8")
+        if not quiet and not json_out:
+            click.echo(f"Report  : {report_json}")
+
+    # Non-zero exit when the deck silently dropped shapes — useful for CI.
+    if not result.editability_passed:
+        sys.exit(3)
+
+
+def _error_remediation(exc: BaseException) -> list[str]:
+    """Map exception kinds to actionable next-step commands."""
+    name = type(exc).__name__
+    msg = str(exc)
+    out: list[str] = []
+    if name == "FileNotFoundError" or "no such file" in msg.lower():
+        out.append("Verify the input path: `ls -la <path>`")
+        out.append("Or pipe HTML via stdin: `cat slide.html | slidify convert - out.pptx`")
+    if "playwright" in msg.lower() or "chromium" in msg.lower():
+        out.append("Run `slidify doctor` to verify Chromium is installed.")
+        out.append("Install with: `playwright install chromium --with-deps`")
+    if "soffice" in msg.lower() or "libreoffice" in msg.lower():
+        out.append("Install LibreOffice: `apt-get install -y libreoffice-impress`")
+        out.append("Or skip the oracle: `--no-oracle`")
+    if "no slides produced" in msg.lower():
+        out.append("Add `<!DOCTYPE html>` between slides, or pass a directory of per-slide files.")
+        out.append("Read: `slidify guide authoring --section 'Hard contract'`")
+    if not out:
+        out.append("Run `slidify doctor` to check the environment.")
+        out.append("Read `slidify guide troubleshooting`.")
+    return out
+
+
+def _next_steps(result) -> list[str]:
+    """Suggest concrete follow-up commands based on this conversion's state.
+
+    Acts as an instruction-delivery channel: the CLI tells the LLM what to do
+    next. Order matters — most-actionable first.
+    """
+    hints: list[str] = []
+    if not result.editability_passed and result.editability_failing_slides:
+        hints.append(
+            "Editability drift — re-render the failing slides individually:  "
+            f"slidify convert <slide.html> <out.pptx>  (slides: "
+            f"{', '.join(map(str, result.editability_failing_slides))})"
+        )
+    failing = [r for r in result.fidelity_reports if not r.passed]
+    if failing:
+        hints.append(
+            f"{len(failing)} slide(s) failed the SSIM/OCR oracle. "
+            "Read `slidify guide troubleshooting --section 'native_area_ratio low'`."
+        )
+    if result.native_area_ratio < 0.6:
+        hints.append(
+            f"Low native_area_ratio ({result.native_area_ratio:.2f}). "
+            "Read `slidify guide authoring --section 'What forces a raster'`."
+        )
+    if result.unmatched_signatures:
+        hints.append(
+            f"{len(result.unmatched_signatures)} unmatched DOM signatures recorded. "
+            "Run `slidify harvest <corpus_dir>` to surface Tier-0 candidates."
+        )
+    if not hints:
+        hints.append("Open the .pptx in PowerPoint to verify editability.")
+        hints.append("Run `slidify field <report.json> native_area_ratio` to extract metrics.")
+    return hints
+
+
+def _print_next_steps(result) -> None:
+    steps = _next_steps(result)
+    if not steps:
+        return
+    click.echo(click.style("Next:", bold=True))
+    for s in steps:
+        click.echo(click.style("  → ", dim=True) + s)
+
+
+def _print_summary(result) -> None:
+    """Pretty-print the ConversionResult as a labeled key/value block."""
+    G = lambda s: click.style(s, fg="green")  # noqa: E731
+    Y = lambda s: click.style(s, fg="yellow")  # noqa: E731
+    R = lambda s: click.style(s, fg="red")    # noqa: E731
+    D = lambda s: click.style(s, dim=True)    # noqa: E731
+
+    click.echo(D("─" * 64))
+    click.echo(f"{'Output':<22}{result.pptx_path}")
+    click.echo(f"{'Slides':<22}{result.n_slides}")
+    nr = result.native_area_ratio
+    nr_color = G if nr >= 0.85 else Y if nr >= 0.6 else R
+    click.echo(f"{'Native area ratio':<22}{nr_color(f'{nr:.3f}')}")
+    click.echo(f"{'Pattern coverage':<22}{result.pattern_coverage:.3f}")
     if result.pattern_hits:
         top = sorted(result.pattern_hits.items(), key=lambda kv: -kv[1])[:6]
-        click.echo("Top patterns: " + ", ".join(f"{k}×{v}" for k, v in top))
-    click.echo(f"Cache hit rate: {result.cache_hit_rate:.3f}")
-    click.echo(f"LLM calls: {result.llm_calls} (cost ≈ ${result.total_cost_usd:.4f})")
-    click.echo(f"Decisions by tier: {result.decisions_by_tier}")
-    click.echo(f"Elapsed: {result.elapsed_seconds:.2f}s")
+        click.echo(f"{'Top patterns':<22}" + ", ".join(f"{k}×{v}" for k, v in top))
+    click.echo(f"{'Cache hit rate':<22}{result.cache_hit_rate:.3f}")
+    click.echo(
+        f"{'LLM calls':<22}{result.llm_calls} "
+        + D(f"(≈ ${result.total_cost_usd:.4f})")
+    )
+    if result.decisions_by_tier:
+        tiers = ", ".join(
+            f"{k}={v}" for k, v in sorted(result.decisions_by_tier.items())
+        )
+        click.echo(f"{'Decisions by tier':<22}{tiers}")
+    click.echo(f"{'Elapsed':<22}{result.elapsed_seconds:.2f}s")
+
     if result.fidelity_reports:
         passed = sum(1 for r in result.fidelity_reports if r.passed)
-        click.echo(
-            f"Oracle: {passed}/{len(result.fidelity_reports)} slides passed "
-            f"(mean SSIM={sum(r.ssim for r in result.fidelity_reports) / len(result.fidelity_reports):.3f})"
-        )
+        n = len(result.fidelity_reports)
+        ssim = sum(r.ssim for r in result.fidelity_reports) / n
+        verdict = G(f"{passed}/{n}") if passed == n else Y(f"{passed}/{n}")
+        click.echo(f"{'Oracle':<22}{verdict} passed " + D(f"(mean SSIM={ssim:.3f})"))
+
     if result.editability_intended_total or result.editability_actual_total:
-        status = "ok" if result.editability_passed else "DRIFT"
+        if result.editability_passed:
+            status = G("ok")
+        else:
+            status = R("DRIFT")
         click.echo(
-            f"Editability: {status} "
-            f"(actual {result.editability_actual_total} / intended "
-            f"{result.editability_intended_total})"
+            f"{'Editability':<22}{status} "
+            + D(f"({result.editability_actual_total}/{result.editability_intended_total} shapes)")
         )
         if result.editability_failing_slides:
             click.echo(
-                "  Slides with dropped shapes: "
+                D("  Slides with dropped shapes: ")
                 + ", ".join(str(i) for i in result.editability_failing_slides)
             )
     if result.unmatched_signatures:
         click.echo(
-            f"Unmatched signatures: {len(result.unmatched_signatures)}"
-            " (run `slidify harvest` for suggestions)"
+            D(f"Unmatched signatures  {len(result.unmatched_signatures)} "
+              "(run `slidify harvest` to surface candidates)")
         )
-
-    if report_json:
-        report_json.write_text(result.model_dump_json(indent=2), encoding="utf-8")
-        click.echo(f"Report: {report_json}")
+    click.echo(D("─" * 64))
 
 
 # ---------------------------------------------------------------------------
@@ -239,10 +405,28 @@ def harvest(input_path: Path, top: int, out_json: Path | None) -> None:
 # ---------------------------------------------------------------------------
 
 
-@click.group(invoke_without_command=True)
+@click.group(
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.version_option(__version__, "-V", "--version", prog_name="slidify")
 @click.pass_context
 def cli(ctx: click.Context) -> None:
-    """slidify — render-and-classify HTML to PPTX."""
+    """slidify — render HTML decks into editable PPTX.
+
+    Quick start:
+
+        slidify deck.html deck.pptx               # convert (default action)
+        slidify doctor                            # check system dependencies
+        slidify convert slides/ deck.pptx --json  # JSON report on stdout
+        slidify compat --level planned            # roadmap of CSS support
+
+    Environment variables (read by ConversionConfig.from_env()):
+
+        SLIDIFY_NO_ORACLE   SLIDIFY_NO_TIER3   SLIDIFY_LOW_MEMORY
+        SLIDIFY_NO_FONTS    SLIDIFY_LLM_BACKEND   SLIDIFY_LLM_MODEL
+        SLIDIFY_RENDER_CONCURRENCY
+    """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
 
@@ -250,7 +434,7 @@ def cli(ctx: click.Context) -> None:
 @cli.command(name="convert")
 @click.argument(
     "input_path",
-    type=click.Path(exists=True, dir_okay=True, file_okay=True, path_type=Path),
+    type=click.Path(exists=False, dir_okay=True, file_okay=True, path_type=Path),
 )
 @click.argument("output_pptx", type=click.Path(dir_okay=False, path_type=Path))
 @_convert_options
@@ -268,12 +452,27 @@ def convert_cmd(
     no_differential_render: bool,
     no_embed_fonts: bool,
     report_json: Path | None,
+    quiet: bool,
+    json_out: bool,
 ) -> None:
-    """Convert INPUT_PATH (file or directory) to OUTPUT_PPTX."""
+    """Convert INPUT_PATH (file or directory) to OUTPUT_PPTX.
+
+    INPUT_PATH may be:
+
+      * a single .html file (split on `<!DOCTYPE html>` separators)
+      * a directory of *.html files (each treated as one slide,
+        sorted lexicographically — name them 01.html, 02.html, …)
+
+    Exit codes:
+        0  success
+        2  conversion error (rendering, LLM, etc.)
+        3  editability drift (shapes silently dropped from output)
+    """
     _run_convert(
         input_path, output_pptx, no_tier3, no_oracle, llm_backend, llm_model,
         google_project, google_location, render_concurrency, low_memory,
         no_differential_render, no_embed_fonts, report_json,
+        quiet, json_out,
     )
 
 
@@ -416,12 +615,622 @@ def capture_gif_cmd(
     click.echo(f"Wrote {out_path} ({out_path.stat().st_size / 1024:.1f} KiB)")
 
 
+# ---------------------------------------------------------------------------
+# version / doctor — environment introspection
+# ---------------------------------------------------------------------------
+
+
+@cli.command(name="version")
+@click.option("--json", "json_out", is_flag=True, help="Print machine-readable JSON.")
+def version_cmd(json_out: bool) -> None:
+    """Print slidify version + Python + key runtime versions."""
+    import platform
+
+    info = {
+        "slidify": __version__,
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+    }
+    for pkg in ("playwright", "pptx", "PIL", "anthropic", "google.genai"):
+        try:
+            mod = __import__(pkg)
+            info[pkg] = getattr(mod, "__version__", "unknown")
+        except Exception:
+            info[pkg] = "not installed"
+
+    if json_out:
+        click.echo(json.dumps(info, indent=2))
+        return
+    click.echo(f"slidify {info['slidify']} (python {info['python']})")
+    click.echo(f"platform: {info['platform']}")
+    for k in ("playwright", "pptx", "PIL", "anthropic", "google.genai"):
+        click.echo(f"  {k:<16}{info[k]}")
+
+
+@cli.command(name="doctor")
+@click.option("--json", "json_out", is_flag=True, help="Print machine-readable JSON.")
+def doctor_cmd(json_out: bool) -> None:
+    """Verify that the runtime environment can convert decks end-to-end.
+
+    Checks for:
+      * LibreOffice (oracle pass: PPTX → PNG)
+      * tesseract (oracle OCR recall)
+      * poppler-utils' `pdftoppm` (LibreOffice fallback path)
+      * Playwright's bundled Chromium
+      * at least one LLM backend (env vars)
+      * Inter font (default deck typeface)
+
+    Exits 0 if every required check passes, 1 otherwise (LLM / fonts are
+    optional and never fail the doctor).
+    """
+    import os
+
+    checks: list[dict] = []
+
+    def check(name: str, ok: bool, detail: str, *, optional: bool = False) -> None:
+        checks.append({"name": name, "ok": ok, "detail": detail, "optional": optional})
+
+    # Binaries
+    for binary, label, required in [
+        ("soffice", "LibreOffice (oracle)", True),
+        ("libreoffice", "LibreOffice (alt)", False),
+        ("tesseract", "Tesseract OCR", True),
+        ("pdftoppm", "poppler-utils pdftoppm", True),
+    ]:
+        path = shutil.which(binary)
+        check(label, path is not None, path or "missing on PATH", optional=not required)
+
+    # Playwright + Chromium
+    try:
+        from playwright._impl._driver import compute_driver_executable  # type: ignore
+
+        compute_driver_executable()
+        # We can't easily probe Chromium without launching it, but driver presence
+        # is a strong signal.
+        check("Playwright driver", True, "available", optional=False)
+    except Exception as e:
+        check("Playwright driver", False, f"{type(e).__name__}: {e}", optional=False)
+
+    chromium_dir = Path.home() / ".cache" / "ms-playwright"
+    if env := os.environ.get("PLAYWRIGHT_BROWSERS_PATH"):
+        chromium_dir = Path(env)
+    has_chromium = chromium_dir.is_dir() and any(chromium_dir.glob("chromium-*"))
+    check(
+        "Playwright Chromium",
+        has_chromium,
+        str(chromium_dir) if has_chromium else (
+            f"not found at {chromium_dir} — run `playwright install chromium`"
+        ),
+        optional=False,
+    )
+
+    # LLM backends — any one is enough; none is acceptable (raster fallback).
+    llm_present = any([
+        os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"),
+        os.environ.get("ANTHROPIC_API_KEY"),
+        os.environ.get("GOOGLE_CLOUD_PROJECT"),
+    ])
+    detected: list[str] = []
+    if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
+        detected.append("gemini-aistudio")
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        detected.append("anthropic")
+    if os.environ.get("GOOGLE_CLOUD_PROJECT"):
+        detected.append("vertex (gemini/claude)")
+    check(
+        "LLM backend",
+        llm_present,
+        ", ".join(detected) if detected else "none — tier 3 falls back to Raster",
+        optional=True,
+    )
+
+    # Inter font (default deck face).
+    inter_present = False
+    try:
+        from slidify.font_embed import discover_inter
+
+        inter_present = discover_inter() is not None
+    except Exception:
+        pass
+    check(
+        "Inter font",
+        inter_present,
+        "found" if inter_present else "missing — install fonts-inter",
+        optional=True,
+    )
+
+    if json_out:
+        click.echo(json.dumps({"checks": checks}, indent=2))
+    else:
+        for c in checks:
+            mark = (
+                click.style("✓", fg="green") if c["ok"]
+                else click.style("?", fg="yellow") if c["optional"]
+                else click.style("✗", fg="red")
+            )
+            label = c["name"]
+            tag = click.style(" (optional)", dim=True) if c["optional"] else ""
+            click.echo(f"  {mark}  {label:<26}{tag} {click.style(c['detail'], dim=True)}")
+
+    failed_required = [c for c in checks if not c["ok"] and not c["optional"]]
+    if failed_required:
+        if not json_out:
+            click.echo()
+            click.echo(click.style("Missing required dependencies. See README §Install.", fg="red"))
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# manifest — machine-readable description of the CLI for LLM agents
+# ---------------------------------------------------------------------------
+
+
+_MANIFEST: dict = {
+    "tool": "slidify",
+    "version": __version__,
+    "summary": "Convert HTML decks to editable PPTX.",
+    "exit_codes": {
+        "0": "success",
+        "1": "doctor: required system dependency missing",
+        "2": "conversion error (input not found, render/LLM failure)",
+        "3": "editability drift — shapes silently dropped from output",
+    },
+    "env_vars": {
+        "SLIDIFY_NO_ORACLE":         "1 to skip the LibreOffice fidelity oracle",
+        "SLIDIFY_NO_TIER3":          "1 to skip the LLM adjudicator",
+        "SLIDIFY_LOW_MEMORY":        "1 to drop per-slide state right after emit",
+        "SLIDIFY_NO_FONTS":          "1 to skip embedding source fonts",
+        "SLIDIFY_LLM_BACKEND":       "gemini-aistudio | gemini-vertex | anthropic | claude-vertex",
+        "SLIDIFY_LLM_MODEL":         "model id override for the chosen backend",
+        "SLIDIFY_RENDER_CONCURRENCY":"int, slides rendered in parallel (default 4)",
+        "ANTHROPIC_API_KEY":         "credential for `anthropic` backend",
+        "GEMINI_API_KEY":            "credential for `gemini-aistudio` backend",
+        "GOOGLE_CLOUD_PROJECT":      "GCP project for Vertex backends",
+        "GOOGLE_CLOUD_LOCATION":     "GCP region for Vertex backends (e.g. us-east5)",
+    },
+    "commands": [
+        {
+            "name": "convert",
+            "summary": "Convert an HTML deck to PPTX.",
+            "usage": "slidify convert <input> <output.pptx> [options]",
+            "args": [
+                {"name": "input", "type": "path|-", "desc": "HTML file, directory of HTML files, or `-` for stdin"},
+                {"name": "output", "type": "path", "desc": "Destination .pptx path"},
+            ],
+            "options": [
+                {"name": "--no-oracle",            "desc": "skip fidelity oracle (faster, no SSIM/OCR check)"},
+                {"name": "--no-tier3",             "desc": "skip LLM adjudicator (raster fallback for ambiguous units)"},
+                {"name": "--low-memory",           "desc": "drop per-slide state after emit; disables auto-correct"},
+                {"name": "--no-embed-fonts",       "desc": "skip embedding source fonts"},
+                {"name": "--no-differential-render","desc": "skip the second decoration-only screenshot"},
+                {"name": "--render-concurrency N", "desc": "slides rendered in parallel (default 4)"},
+                {"name": "--llm-backend X",        "desc": "force LLM backend (auto-detected otherwise)"},
+                {"name": "--llm-model X",          "desc": "override default model"},
+                {"name": "--report-json PATH",     "desc": "write full ConversionResult to PATH"},
+                {"name": "--quiet, -q",            "desc": "print only the output path"},
+                {"name": "--json",                 "desc": "print the ConversionResult as JSON to stdout"},
+            ],
+            "examples": [
+                {"desc": "Convert a single file",
+                 "cmd":  "slidify convert deck.html deck.pptx"},
+                {"desc": "Fast preview (no oracle, no LLM)",
+                 "cmd":  "slidify convert deck.html out.pptx --no-oracle --no-tier3"},
+                {"desc": "Convert from stdin",
+                 "cmd":  "cat deck.html | slidify convert - out.pptx --json"},
+                {"desc": "Convert a directory of per-slide files",
+                 "cmd":  "slidify convert slides/ deck.pptx"},
+            ],
+        },
+        {
+            "name": "harvest",
+            "summary": "Run a corpus and rank unmatched DOM signatures (Tier-0 candidates).",
+            "usage": "slidify harvest <dir> [--top N] [--out-json PATH]",
+            "examples": [
+                {"desc": "Top 20 unmatched signatures across a corpus",
+                 "cmd":  "slidify harvest examples/corpus/ --top 20 --out-json harvest.json"},
+            ],
+        },
+        {
+            "name": "compat",
+            "summary": "Print the CSS/HTML compatibility matrix.",
+            "usage": "slidify compat [--format markdown|json] [--level native|raster|partial|unsupported|planned|all]",
+            "examples": [
+                {"desc": "Find what slidify currently rasters",
+                 "cmd":  "slidify compat --level raster"},
+            ],
+        },
+        {
+            "name": "capture-gif",
+            "summary": "Render an animated HTML slide to an animated GIF.",
+            "usage": "slidify capture-gif <html> [--out FILE] [--duration MS] [--fps N]",
+        },
+        {
+            "name": "doctor",
+            "summary": "Verify system deps (LibreOffice, tesseract, Chromium, fonts).",
+            "usage": "slidify doctor [--json]",
+        },
+        {
+            "name": "version",
+            "summary": "Print version of slidify and key runtime libraries.",
+            "usage": "slidify version [--json]",
+        },
+        {
+            "name": "manifest",
+            "summary": "Print this manifest (machine-readable CLI surface).",
+            "usage": "slidify manifest [<command>] [--brief]",
+            "examples": [
+                {"desc": "Just the command index", "cmd": "slidify manifest --brief"},
+                {"desc": "Full spec for one command", "cmd": "slidify manifest convert"},
+            ],
+        },
+        {
+            "name": "guide",
+            "summary": "Read shipped long-form guides with built-in section/grep helpers.",
+            "usage": "slidify guide [<topic>] [--toc] [--section H] [--grep RX] [--search RX]",
+            "examples": [
+                {"desc": "List all guides", "cmd": "slidify guide"},
+                {"desc": "Read one", "cmd": "slidify guide authoring"},
+                {"desc": "Just the headings", "cmd": "slidify guide authoring --toc"},
+                {"desc": "One section", "cmd": "slidify guide authoring --section 'What forces a raster'"},
+                {"desc": "Grep across all guides", "cmd": "slidify guide --search 'tier 0'"},
+            ],
+        },
+        {
+            "name": "field",
+            "summary": "Extract a dotted field from a JSON file (built-in jq-lite).",
+            "usage": "slidify field <json_path> <dotted.path>",
+            "examples": [
+                {"desc": "Single scalar", "cmd": "slidify field report.json native_area_ratio"},
+                {"desc": "Nested list",   "cmd": "slidify field report.json fidelity_reports.0.ssim"},
+            ],
+        },
+    ],
+    "stable_output_schema": {
+        "convert --json": {
+            "pptx_path":                  "string",
+            "n_slides":                   "int",
+            "native_area_ratio":          "float (0..1, higher = more editable)",
+            "pattern_coverage":           "float (0..1)",
+            "cache_hit_rate":             "float (0..1)",
+            "llm_calls":                  "int",
+            "total_cost_usd":             "float",
+            "elapsed_seconds":            "float",
+            "decisions_by_tier":          "dict[str, int]",
+            "fidelity_reports":           "list — per-slide SSIM/OCR scores",
+            "editability_passed":         "bool — true if every intended shape survived",
+            "editability_failing_slides": "list[int]",
+            "unmatched_signatures":       "list — Tier-0 candidates",
+        },
+    },
+    "tips_for_agents": [
+        "Always run `slidify doctor --json` once before a session to confirm the environment.",
+        "Pipe HTML through stdin for one-shot conversions; no temp files needed.",
+        "Use `--json` for programmatic output. Errors come back as `{error, type, stage, _remediation[]}`.",
+        "Successful `--json` results include a `_next` array — concrete follow-up commands tailored to this run.",
+        "Don't shell out to `jq` — use `slidify field <report.json> <dotted.path>`.",
+        "Don't shell out to `head`/`grep` for guides — use `slidify guide <topic> --section/--toc/--grep`.",
+        "Drill into the manifest progressively: `slidify manifest --brief` → `slidify manifest convert`.",
+        "Use `--no-oracle --no-tier3` for fast iteration; turn them on for the final emit.",
+        "If `editability_passed` is false, inspect `editability_failing_slides` and re-emit those.",
+        "When authoring slides, read `slidify guide authoring` first — every shipped guide is tuned for native_area_ratio.",
+    ],
+}
+
+
+@cli.command(name="manifest")
+@click.argument("command", required=False)
+@click.option(
+    "--brief",
+    is_flag=True,
+    help="Drop schemas + tips_for_agents — just the command index.",
+)
+def manifest_cmd(command: str | None, brief: bool) -> None:
+    """Print a machine-readable description of the CLI surface.
+
+    Progressive disclosure:
+
+    * `slidify manifest`           — full manifest
+    * `slidify manifest --brief`   — command index only (cheap to load)
+    * `slidify manifest convert`   — spec for one command (drill-down)
+
+    Designed for LLM agents to introspect before invoking slidify: every
+    subcommand, option, env var, exit code and example is listed, plus a
+    stable schema for `--json` payloads so callers can rely on field names
+    without reading source.
+    """
+    if command:
+        for c in _MANIFEST["commands"]:
+            if c["name"] == command:
+                click.echo(json.dumps(c, indent=2))
+                return
+        click.echo(json.dumps(
+            {"error": f"unknown command: {command}",
+             "known": [c["name"] for c in _MANIFEST["commands"]]},
+            indent=2,
+        ))
+        sys.exit(2)
+
+    if brief:
+        click.echo(json.dumps({
+            "tool": _MANIFEST["tool"],
+            "version": _MANIFEST["version"],
+            "summary": _MANIFEST["summary"],
+            "commands": [
+                {"name": c["name"], "summary": c["summary"]}
+                for c in _MANIFEST["commands"]
+            ],
+            "_next": [
+                "slidify manifest <command>  # drill into one command",
+                "slidify guide               # list of long-form guides",
+                "slidify doctor --json       # verify environment",
+            ],
+        }, indent=2))
+        return
+
+    click.echo(json.dumps(_MANIFEST, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# guide — long-form prose, with section + grep helpers (no need for
+# `head`, `grep`, or `awk` on the host).
+# ---------------------------------------------------------------------------
+
+
+def _guides_dir() -> Path:
+    return Path(__file__).parent / "guides"
+
+
+def _list_guides() -> list[tuple[str, str]]:
+    """Return [(topic, one_line_summary), ...] from H1 of each guide."""
+    items: list[tuple[str, str]] = []
+    d = _guides_dir()
+    if not d.exists():
+        return items
+    for path in sorted(d.glob("*.md")):
+        topic = path.stem
+        text = path.read_text(encoding="utf-8")
+        # First non-empty line after the H1 header is our summary.
+        lines = [ln.strip() for ln in text.splitlines()]
+        summary = ""
+        in_code = False
+        for i, ln in enumerate(lines):
+            if ln.startswith("# "):
+                # First prose line that isn't a code fence, table, or header.
+                for ln2 in lines[i + 1:]:
+                    if ln2.startswith("```"):
+                        in_code = not in_code
+                        continue
+                    if in_code:
+                        continue
+                    if not ln2 or ln2.startswith(("#", "|", "-", "*", "1.", "2.")):
+                        continue
+                    summary = ln2
+                    break
+                break
+        items.append((topic, summary))
+    return items
+
+
+def _extract_section(md: str, header: str) -> str:
+    """Return the body of the first H2 (## ...) section whose title contains
+    `header` (case-insensitive substring), up to the next H2/H1."""
+    target = header.lower()
+    out: list[str] = []
+    in_section = False
+    for line in md.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("## "):
+            title = stripped[3:].strip().lower()
+            if in_section:
+                break  # next section started — stop
+            if target in title:
+                in_section = True
+                out.append(line)
+                continue
+        elif stripped.startswith("# ") and in_section:
+            break
+        if in_section:
+            out.append(line)
+    return "\n".join(out).rstrip()
+
+
+def _toc(md: str) -> str:
+    """Markdown table of contents (H1 + H2 headers only)."""
+    lines: list[str] = []
+    for ln in md.splitlines():
+        s = ln.lstrip()
+        if s.startswith("# "):
+            lines.append(s[2:].strip())
+        elif s.startswith("## "):
+            lines.append("  " + s[3:].strip())
+    return "\n".join(lines)
+
+
+def _grep(md: str, pattern: str, context: int = 1) -> str:
+    """Return matching lines with `context` lines before/after each hit."""
+    import re
+
+    rx = re.compile(pattern, re.IGNORECASE)
+    lines = md.splitlines()
+    keep = [False] * len(lines)
+    for i, ln in enumerate(lines):
+        if rx.search(ln):
+            for j in range(max(0, i - context), min(len(lines), i + context + 1)):
+                keep[j] = True
+    out: list[str] = []
+    last_kept = -2
+    for i, k in enumerate(keep):
+        if k:
+            if last_kept >= 0 and i - last_kept > 1:
+                out.append("--")
+            out.append(f"{i + 1}: {lines[i]}")
+            last_kept = i
+    return "\n".join(out)
+
+
+@cli.command(name="guide")
+@click.argument("topic", required=False)
+@click.option("--section", default=None, help="Extract only this H2 section (case-insensitive substring).")
+@click.option("--toc", "show_toc", is_flag=True, help="Print the table of contents only.")
+@click.option("--grep", "grep_pattern", default=None, help="Show lines matching this regex (with surrounding context).")
+@click.option("--search", default=None, help="Search ALL guides for the regex; print matching topics + lines.")
+@click.option("--json", "json_out", is_flag=True, help="Machine-readable output for the list / search modes.")
+def guide_cmd(
+    topic: str | None,
+    section: str | None,
+    show_toc: bool,
+    grep_pattern: str | None,
+    search: str | None,
+    json_out: bool,
+) -> None:
+    """Read shipped long-form guides, with built-in section / grep helpers.
+
+    Examples:
+
+    \b
+        slidify guide                              # list all guides
+        slidify guide authoring                    # full text
+        slidify guide authoring --toc              # just the headings
+        slidify guide authoring --section "What"   # one H2 section
+        slidify guide authoring --grep raster      # lines mentioning "raster"
+        slidify guide --search "Tier 0"            # search all guides
+    """
+    # Cross-guide search.
+    if search:
+        import re
+
+        rx = re.compile(search, re.IGNORECASE)
+        hits: list[dict] = []
+        for t, _ in _list_guides():
+            text = (_guides_dir() / f"{t}.md").read_text(encoding="utf-8")
+            for i, ln in enumerate(text.splitlines(), 1):
+                if rx.search(ln):
+                    hits.append({"topic": t, "line": i, "text": ln.rstrip()})
+        if json_out:
+            click.echo(json.dumps({"query": search, "hits": hits}, indent=2))
+        else:
+            if not hits:
+                click.echo(f"no matches for /{search}/")
+                return
+            for h in hits:
+                click.echo(f"{h['topic']:<22} {h['line']:>4}: {h['text']}")
+        return
+
+    # No topic: list mode.
+    if not topic:
+        items = _list_guides()
+        if json_out:
+            click.echo(json.dumps(
+                {"guides": [{"topic": t, "summary": s} for t, s in items]},
+                indent=2,
+            ))
+            return
+        if not items:
+            click.echo("no guides shipped")
+            return
+        click.echo("Available guides:")
+        for t, s in items:
+            click.echo(f"  {click.style(t, fg='cyan'):<32} {click.style(s, dim=True)}")
+        click.echo()
+        click.echo("Read one with:  slidify guide <topic>")
+        click.echo("Drill in with:  slidify guide <topic> --section ...  --grep ...  --toc")
+        return
+
+    # Specific topic.
+    path = _guides_dir() / f"{topic}.md"
+    if not path.exists():
+        known = [t for t, _ in _list_guides()]
+        if json_out:
+            click.echo(json.dumps({"error": f"unknown guide: {topic}", "known": known}, indent=2))
+        else:
+            click.echo(f"unknown guide: {topic}", err=True)
+            click.echo(f"available: {', '.join(known)}", err=True)
+        sys.exit(2)
+    md = path.read_text(encoding="utf-8")
+
+    if show_toc:
+        click.echo(_toc(md))
+        return
+    if section:
+        body = _extract_section(md, section)
+        if not body:
+            click.echo(f"no section matching '{section}' in {topic}", err=True)
+            sys.exit(2)
+        click.echo(body)
+        return
+    if grep_pattern:
+        result = _grep(md, grep_pattern)
+        if not result:
+            click.echo(f"no matches for /{grep_pattern}/ in {topic}", err=True)
+            sys.exit(1)
+        click.echo(result)
+        return
+
+    click.echo(md)
+
+
+# ---------------------------------------------------------------------------
+# field — pull a single dotted path out of a JSON file (built-in jq-lite,
+# so binary distributions without jq still work).
+# ---------------------------------------------------------------------------
+
+
+@cli.command(name="field")
+@click.argument("json_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("dotted_path")
+def field_cmd(json_path: Path, dotted_path: str) -> None:
+    """Extract a dotted field from a JSON file.
+
+    Numeric segments index lists; string segments index dicts.
+
+    \b
+    Examples:
+        slidify field report.json native_area_ratio
+        slidify field report.json fidelity_reports.0.ssim
+        slidify field report.json decisions_by_tier.tier0
+    """
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        click.echo(f"slidify: invalid JSON: {e}", err=True)
+        sys.exit(2)
+
+    cur = data
+    for seg in dotted_path.split("."):
+        if isinstance(cur, list):
+            try:
+                cur = cur[int(seg)]
+            except (ValueError, IndexError) as e:
+                click.echo(f"slidify: cannot index {type(cur).__name__} with '{seg}': {e}", err=True)
+                sys.exit(2)
+        elif isinstance(cur, dict):
+            if seg not in cur:
+                click.echo(
+                    f"slidify: key '{seg}' not in object (have: {', '.join(sorted(cur.keys()))})",
+                    err=True,
+                )
+                sys.exit(2)
+            cur = cur[seg]
+        else:
+            click.echo(f"slidify: cannot descend into {type(cur).__name__} at '{seg}'", err=True)
+            sys.exit(2)
+
+    if isinstance(cur, (dict, list)):
+        click.echo(json.dumps(cur, indent=2))
+    else:
+        click.echo(str(cur))
+
+
 def main() -> None:
     """Entry point shim: when called with positional args that look like
     (input, output), dispatch to convert directly so the legacy
     `slidify foo.html bar.pptx` invocation keeps working."""
     args = sys.argv[1:]
-    known_subs = {"convert", "harvest", "compat", "--help", "-h"}
+    known_subs = {
+        "convert", "harvest", "compat", "capture-gif",
+        "doctor", "version", "manifest", "guide", "field",
+        "--help", "-h", "--version", "-V",
+    }
     if args and not args[0].startswith("-") and args[0] not in known_subs:
         # Implicit convert: rewrite to `slidify convert ...`
         sys.argv = [sys.argv[0], "convert", *args]

--- a/slidify/guides/agent-quickstart.md
+++ b/slidify/guides/agent-quickstart.md
@@ -1,0 +1,77 @@
+# Agent quickstart
+
+A 60-second tour for an LLM agent that has never used slidify before.
+
+## Step 1 — verify the environment
+
+```bash
+slidify doctor --json
+```
+
+Look at `checks[].ok`. Any required check failing means: install the missing
+binary or run inside the slidify Docker image (see `slidify guide binary`).
+
+## Step 2 — discover the surface
+
+```bash
+slidify manifest                        # brief: list of commands
+slidify manifest convert                # detailed: convert spec, schema
+slidify guide                           # list of long-form guides
+slidify guide authoring                 # how to write good HTML
+```
+
+## Step 3 — convert
+
+```bash
+# From a file
+slidify convert deck.html out.pptx --json
+
+# From stdin (no temp files needed)
+cat slide.html | slidify convert - out.pptx --json
+
+# Fast preview (no oracle, no LLM)
+slidify convert deck.html out.pptx --no-oracle --no-tier3 --json
+```
+
+## Step 4 — interpret the result
+
+In `--json` mode the response is a `ConversionResult`:
+
+* `native_area_ratio`           — 0..1, **higher is better** (more editable).
+* `editability_passed`          — bool. False means shapes were silently dropped.
+* `editability_failing_slides`  — list of slide indices to inspect.
+* `fidelity_reports[].passed`   — per-slide SSIM/OCR check.
+* `unmatched_signatures`        — Tier-0 candidates (run `slidify harvest`).
+* `_next`                       — suggested follow-up commands.
+* `_remediation` (on error)     — actionable fix suggestions.
+
+## Step 5 — extract a single field without jq
+
+```bash
+slidify field out.json native_area_ratio        # → 0.873
+slidify field out.json fidelity_reports.0.ssim  # → 0.961
+```
+
+## Step 6 — iterate
+
+```bash
+slidify guide authoring --section "What forces a raster"
+slidify guide authoring --grep "decorate"
+```
+
+If a slide's `native_area_ratio` is low, the most common causes:
+
+1. `background-image: url(...)` → swap for inline gradient or SVG.
+2. `filter: blur()` on visible elements → drop the blur.
+3. `<canvas>` → render to inline SVG instead.
+4. Custom `@font-face` → use Inter.
+
+## Recipe: a robust agent loop
+
+```
+1. slidify doctor --json                       # confirm env
+2. (write slide.html using `slidify guide authoring`)
+3. slidify convert slide.html out.pptx --json --report-json report.json
+4. if .editability_passed == false → re-emit failing slides
+5. if .native_area_ratio < 0.85   → read report, swap raster offenders, retry
+```

--- a/slidify/guides/api.md
+++ b/slidify/guides/api.md
@@ -1,0 +1,84 @@
+# Python API
+
+```python
+import asyncio
+from slidify import convert, convert_sync, ConversionConfig
+
+# Sync — easiest for scripts.
+result = convert_sync("deck.html", "deck.pptx", ConversionConfig.fast())
+print(result.native_area_ratio)
+
+# Async — when you already have an event loop.
+async def main():
+    cfg = ConversionConfig(run_oracle=True, run_tier3=True)
+    return await convert("deck.html", "deck.pptx", cfg)
+
+asyncio.run(main())
+```
+
+## Source forms
+
+`convert(source, pptx_path, config)` accepts five source types:
+
+```python
+await convert(html_string,             "out.pptx", cfg)
+await convert(Path("deck.html"),       "out.pptx", cfg)
+await convert(Path("slides_dir/"),     "out.pptx", cfg)
+await convert(["<html>...</html>", …], "out.pptx", cfg)
+
+async def stream():
+    async for s in fetch_from_db():
+        yield s
+await convert(stream(),                "out.pptx", cfg)
+```
+
+The streaming variant is true streaming — peak memory bounded by
+`render_concurrency`, not deck size.
+
+## Configuration recipes
+
+```python
+ConversionConfig.fast()       # no oracle, no LLM, no editability check
+ConversionConfig.from_env()   # reads SLIDIFY_* env vars (containers, CI)
+ConversionConfig(             # everything; defaults are sensible
+    run_oracle=True,
+    run_tier3=True,
+    render_concurrency=4,
+    differential_render=True,
+    embed_fonts=True,
+)
+```
+
+## Result fields
+
+```python
+class ConversionResult(BaseModel):
+    pptx_path: str
+    n_slides: int
+    native_area_ratio: float           # 0..1, higher = more editable
+    pattern_coverage: float            # 0..1, Tier-0 hit rate
+    cache_hit_rate: float
+    llm_calls: int
+    total_cost_usd: float
+    elapsed_seconds: float
+    decisions_by_tier: dict[str, int]
+    pattern_hits: dict[str, int]
+    fidelity_reports: list[FidelityReport]
+    editability_passed: bool
+    editability_failing_slides: list[int]
+    unmatched_signatures: list[UnmatchedSignature]
+```
+
+## Exceptions
+
+```python
+from slidify import (
+    SlidifyError,            # base
+    RenderError,             # browser / Playwright failures
+    ClassificationError,     # tier1/2/3 pipeline failures
+    EmitError,               # python-pptx output failures
+    OracleError,             # SSIM / OCR oracle failures
+)
+```
+
+All carry optional `slide_index` and `unit_id` attributes for attribution.

--- a/slidify/guides/authoring.md
+++ b/slidify/guides/authoring.md
@@ -1,0 +1,74 @@
+# Authoring HTML for slidify
+
+Goal: produce HTML where the maximum possible fraction of slide area lands as
+**editable PPTX shapes** rather than rasters.
+
+## Hard contract
+
+1. Single self-contained HTML file. All CSS inline in `<style>`. No external
+   stylesheets, no JS. Inline SVG is allowed.
+2. Viewport is exactly **1280 × 720 px**. Pin it:
+   ```html
+   html, body { margin:0; padding:0; width:1280px; height:720px;
+                font-family: Inter, sans-serif; }
+   .slide    { width:1280px; height:720px; box-sizing:border-box;
+               position:relative; overflow:hidden; }
+   ```
+3. Each slide is its own `<!DOCTYPE html>...</html>`. slidify splits a single
+   file on doctype boundaries.
+4. Mark the slide title with `data-pptx-role="title"` (exactly one element).
+5. Use the **Inter** font. slidify embeds it.
+
+## What renders natively (use these aggressively)
+
+* Solid + linear/radial gradients (`background: linear-gradient(...)`).
+* Multi-layer `box-shadow` — each layer becomes a native outer shadow.
+* `border` + `border-radius` — emitted as line + rounded-rect.
+* Inline `<span style="color:...">` / `<em>` / `<b>` — per-run styling.
+* `-webkit-background-clip: text` gradient text.
+* Inline SVG `<rect>`, `<circle>`, `<line>`, `<polygon>`, `<path d="...">`
+  with cubic/quadratic curves.
+* Preset shapes via `clip-path: polygon(...)` or class hints
+  (`.chevron`, `.arrow-right`, `.star`, `.hex`).
+
+## Decoration hints
+
+Add `data-slidify-decorate="HINT"` to elements for layered native effects:
+
+| Hint        | Effect                                  | Use on              |
+|-------------|-----------------------------------------|---------------------|
+| `hero`      | 4-corner mesh glow + hairline           | Hero bg, feature card |
+| `spotlight` | Centered radial blob                    | CTA backgrounds     |
+| `aurora`    | Three horizontal glow bands             | Quote / callout     |
+| `orbit`     | Five distributed blobs                  | Dashboard bg        |
+| `glass`     | Rim highlight + hairline + inset glow   | Stat cards, tiles   |
+| `tactile`   | Strong rim + thin border                | Buttons, pills      |
+| `recessed`  | Inset dark shadow                       | Code blocks         |
+
+3–6 decorated containers per slide is the sweet spot.
+
+## What forces a raster (avoid)
+
+* CSS `filter: blur()` on visible elements
+* SVG `<filter>`, masks, complex clip-paths
+* `transform: rotate(N)` for N ∉ {0, 90, 180, 270}
+* `<canvas>`
+* `background-image: url(...)` (no fetch — use gradients or inline SVG)
+* `@font-face` with custom fonts (only Inter survives)
+* `<table>` (use CSS grid)
+
+## Density target
+
+Per slide: 15–30 distinct visual elements, 2–4 typographic levels, 3–6
+decorated containers, ≥ 1 inline SVG decoration, header (kicker + title)
+and footer (label + page number).
+
+## Verification loop
+
+```bash
+slidify convert slide.html out.pptx --json | jq '.native_area_ratio'
+```
+
+* `native_area_ratio ≥ 0.85` → excellent, mostly editable
+* `0.6 – 0.85` → good, some raster fallbacks
+* `< 0.6` → revisit: probably background images, blurs, or unsupported SVG

--- a/slidify/guides/binary.md
+++ b/slidify/guides/binary.md
@@ -1,0 +1,73 @@
+# Running slidify as a packaged binary
+
+slidify has three runtime dependencies the OS must provide:
+
+| Dep              | Why                                              |
+|------------------|--------------------------------------------------|
+| Chromium         | Renders HTML pixel-accurately (Playwright)       |
+| LibreOffice      | Renders the produced PPTX for the SSIM oracle    |
+| Tesseract OCR    | Per-slide OCR-recall check                       |
+| poppler-utils    | LibreOffice → image fallback path                |
+| Inter font       | Default deck typeface (also embedded in PPTX)    |
+
+A pure-Python binary that bundles only Python deps is therefore not enough.
+slidify ships **two** packaging modes:
+
+## 1. Docker image — recommended
+
+The cleanest way to ship slidify with every dependency pinned:
+
+```bash
+docker build -f packaging/Dockerfile -t slidify:latest .
+docker run --rm -v "$PWD":/work slidify:latest \
+       convert /work/deck.html /work/deck.pptx --json
+```
+
+The image is ~1.6 GB (LibreOffice dominates). Multi-stage build keeps the
+runtime layer minimal.
+
+## 2. PyInstaller onefile — for offline distribution
+
+```bash
+./packaging/build-binary.sh
+# → dist/slidify       (single ELF, ~80 MB; no Python runtime needed)
+```
+
+The ELF bundles:
+
+* Python 3.11 + every Python dependency
+* Playwright driver + Chromium (auto-extracted on first run)
+* slidify package data (patterns, guides, fonts)
+
+It does **not** bundle LibreOffice, Tesseract, or poppler-utils — those must
+exist on the host. Run `./dist/slidify doctor` to verify.
+
+For fully air-gapped environments use the Docker image; the PyInstaller
+binary is only "Python is missing" coverage, not full self-containment.
+
+## 3. Hybrid: binary + companion deps tarball
+
+For private fleets:
+
+```bash
+./packaging/build-binary.sh --with-deps
+# → dist/slidify-bundle.tar.gz
+#   ├── slidify           (ELF)
+#   ├── deps/             (.deb files: libreoffice-core, tesseract, poppler)
+#   └── install.sh        (idempotent installer for the .debs)
+```
+
+`install.sh` runs `dpkg -i` on the deps then symlinks slidify into
+`/usr/local/bin`. Suitable for on-prem nodes that can't apt-get.
+
+## Verifying a packaged binary
+
+After install:
+
+```bash
+slidify doctor                  # human readout
+slidify doctor --json           # machine-readable
+slidify version --json          # versions of everything bundled
+```
+
+`doctor` exits non-zero if a required binary is missing on `$PATH`.

--- a/slidify/guides/troubleshooting.md
+++ b/slidify/guides/troubleshooting.md
@@ -1,0 +1,75 @@
+# Troubleshooting
+
+## `slidify doctor` shows missing binaries
+
+| Missing                | Install (Debian/Ubuntu)                          |
+|------------------------|--------------------------------------------------|
+| LibreOffice            | `apt-get install -y libreoffice-impress`         |
+| Tesseract OCR          | `apt-get install -y tesseract-ocr`               |
+| poppler-utils          | `apt-get install -y poppler-utils`               |
+| Inter font             | `apt-get install -y fonts-inter`                 |
+| Chromium (Playwright)  | `playwright install chromium --with-deps`        |
+
+Or use the prebuilt image: `docker run --rm slidify:latest doctor`.
+
+## `editability_passed=false`
+
+The emitter's intended shape count for a slide differed from what survived
+to disk. Causes, in order of frequency:
+
+1. **A unit's bbox collapsed to 0×0** during promotion. Inspect the slide
+   HTML for elements with `display:none` or `visibility:hidden` that are
+   still in the DOM tree.
+2. **Hint-driven skip went too far**. Review `data-pptx-skip="true"`
+   markers — they remove the element AND its descendants.
+3. **A native shape's geometry was unrepresentable** (e.g., a path with
+   a degenerate curve). The emitter falls back to raster but the count
+   bookkeeping flagged it. Safe to ignore if SSIM passes.
+
+## `native_area_ratio` low (<0.6)
+
+Most common offenders, ranked:
+
+1. `background-image: url(...)`              — inline as data URI or use gradient
+2. `filter: blur(...)` on visible content    — drop the filter
+3. `<canvas>`                                — replace with inline SVG
+4. `transform: rotate(N)` for arbitrary N    — use 0/90/180/270
+5. SVG `<filter>` / mask                     — use simpler shapes
+6. `@font-face` with custom font             — use Inter
+
+Run `slidify compat --level raster` to see every property that forces a raster.
+
+## LLM tier 3 is doing nothing
+
+```bash
+slidify doctor --json | jq '.checks[] | select(.name=="LLM backend")'
+```
+
+If `ok: false`, set one of:
+
+* `ANTHROPIC_API_KEY=...`               (anthropic backend)
+* `GEMINI_API_KEY=...`                  (gemini-aistudio backend)
+* `GOOGLE_CLOUD_PROJECT=... GOOGLE_CLOUD_LOCATION=...`  (Vertex backends)
+
+Or pass `--no-tier3` to silence the warning when running offline.
+
+## "no slides produced from source"
+
+The HTML had no `<!DOCTYPE html>` boundaries and contained no slide content
+the splitter could detect. Either:
+
+* Add `<!DOCTYPE html>` between slides in a multi-slide file, OR
+* Pass a directory of per-slide files (`slide-01.html`, `slide-02.html`, …).
+
+## Conversion is slow (>5s per slide)
+
+* Add `--render-concurrency 8` (only helps if you have CPU cores).
+* Add `--no-oracle` for previews.
+* Add `--no-tier3` if the LLM is the bottleneck (check `llm_calls` in the report).
+* On huge decks, add `--low-memory`.
+
+## Output looks blurry / fonts substituted
+
+Check that the deck face is **Inter** (slidify embeds it by default). If you
+disabled with `--no-embed-fonts`, the destination machine must have Inter
+installed.


### PR DESCRIPTION
## Summary

This PR significantly expands slidify's CLI capabilities with structured JSON output, stdin input support, improved error handling, and comprehensive packaging infrastructure. The changes make slidify suitable for both interactive use and programmatic integration (e.g., LLM agents).

## Key Changes

### CLI Enhancements (`slidify/cli.py`)
- **Structured output**: Added `--json` flag to emit full `ConversionResult` as JSON, plus `--quiet` flag to suppress human summary
- **Stdin support**: `slidify convert - out.pptx` now reads HTML from stdin, enabling pipeline workflows
- **Error remediation**: New `_error_remediation()` function maps exception types to actionable next-step commands (e.g., "Run `slidify doctor`", "Install LibreOffice")
- **Improved summary display**: Refactored `_print_summary()` with color-coded metrics (green for good native_area_ratio, red for failures), aligned key-value formatting, and conditional tier/oracle output
- **Next-step hints**: `_next_steps()` generates LLM-friendly follow-up commands based on conversion state (editability drift, low native_area_ratio, unmatched signatures)
- **New subcommands**: Added `version` and `doctor` commands (stubs for environment introspection)
- **Better help**: Updated docstrings with examples, exit codes, and environment variable documentation

### API Improvements (`slidify/api.py`)
- Added `ConversionConfig.fast()` constructor for lowest-latency profile (no oracle, no LLM, no editability check)
- Added `ConversionConfig.from_env()` to read `SLIDIFY_*` environment variables for container/CI workflows
- Enhanced docstrings with usage examples and configuration recipes

### Packaging Infrastructure
- **Rust bootstrap launcher** (`packaging/bootstrap-rust/`): Single static binary (~5 MB) that auto-provisions Python 3.11 + slidify + Playwright Chromium on first run under `~/.local/share/slidify/`
- **Docker image** (`packaging/Dockerfile`): Multi-stage build bundling Python, all deps, LibreOffice, Tesseract, and Chromium (~1.6 GB)
- **PyInstaller spec** (`packaging/slidify.spec`): Bundles Python + deps + Playwright driver into a single ELF
- **Build script** (`packaging/build-binary.sh`): Orchestrates PyInstaller with optional Chromium/system-deps bundling

### Documentation & Agent Skills
- **Guides**: Added comprehensive markdown guides for authoring HTML, troubleshooting, binary deployment, and agent quickstart
- **Agent skills** (`.claude/` and `.gemini/`): Skill definitions for LLM agents to discover and use slidify's CLI
- **Packaging README**: Comparison of four deployment modes (Rust bootstrap, Docker, PyInstaller, pip)

### Input Validation & Error Handling
- Changed `convert` command's `input_path` validation from `exists=True` to `exists=False` to support stdin (`-`) and provide custom error messages
- Added file existence check with JSON error output when `--json` is used
- Wrapped conversion in try-except to catch and format exceptions with remediation hints

## Notable Implementation Details

- **JSON output augmentation**: When `--json` is used, the response includes a `_next` array of concrete follow-up commands, enabling LLM agents to self-direct without re-reading the manifest
- **Exit codes**: Standardized to 0 (success), 2 (conversion error), 3 (editability drift)
- **Backward compatibility**: Default behavior (no subcommand) still works; `convert` subcommand is explicit
- **Color-coded metrics**: Native area ratio uses green (≥0.85), yellow (≥0.6), red (<0.6) to guide users at a glance
- **Stdin HTML reading**: `_read_stdin_html()` validates TTY and exits cleanly if piped input is missing